### PR TITLE
Refactor services and extend test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ Plots_MARS_PassingBablok/
 Plots_TUNSPEKT/
 Plots_TUNSPEKT_BlandAltman/
 Plots_TUNSPEKT_PassingBablok/
-tests/

--- a/datasource/datasource.py
+++ b/datasource/datasource.py
@@ -1,79 +1,123 @@
+"""Data loading utilities for the M3C2 pipeline.
+
+This module abstracts reading point cloud pairs from various file formats and
+converting them to a common XYZ representation. The main entry point is the
+`DataSource` dataclass which exposes a `load_points` method returning the
+moving epoch, reference epoch and core points as a NumPy array.
+
+External dependencies such as :mod:`py4dgeo`, :mod:`laspy` and
+``plyfile`` are optional and only required for the respective input formats.
+The imports are guarded so that the module can be imported without these
+libraries, which simplifies testing.
+"""
 
 from __future__ import annotations
-import os
+
 import logging
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Tuple
+
 import numpy as np
-import py4dgeo
-from plyfile import PlyData
-import laspy
 
+try:  # Optional dependency
+    import py4dgeo  # type: ignore
+except Exception:  # pragma: no cover - handled in tests
+    py4dgeo = None  # type: ignore
+
+try:  # Optional dependency
+    from plyfile import PlyData  # type: ignore
+except Exception:  # pragma: no cover - handled in tests
+    PlyData = None  # type: ignore
+
+try:  # Optional dependency
+    import laspy  # type: ignore
+except Exception:  # pragma: no cover - handled in tests
+    laspy = None  # type: ignore
+
+
+@dataclass
 class DataSource:
+    """Load point cloud data for a pair of epochs.
+
+    Parameters
+    ----------
+    folder:
+        Base directory containing the files.
+    mov_basename, ref_basename:
+        Basenames of the moving and reference point cloud files without file
+        extension. Supported extensions are ``.xyz``, ``.las``, ``.laz``,
+        ``.ply``, ``.obj`` and ``.gpc``.
+    mov_as_corepoints:
+        If ``True`` use the moving epoch as core points, otherwise the
+        reference epoch.
+    use_subsampled_corepoints:
+        Subsampling factor for the core points.
     """
-    Erwartetes Layout: <folder>/{mov,ref}.{xyz|las|laz|ply|obj|gpc}
-    Priorität:
-      1) Wenn BEIDE .xyz  -> py4dgeo.read_from_xyz
-      2) Wenn BEIDE .las/.laz (gemischt ok) -> py4dgeo.read_from_las
-      3) Wenn BEIDE .ply und read_from_ply existiert -> py4dgeo.read_from_ply
-      4) Sonst: pro Seite in .xyz konvertieren und read_from_xyz
-    Liefert: (mov_epoch, ref_epoch, corepoints_np)
-    """
 
-    def __init__(
-            self, folder: str,
-            mov_basename: str = "mov",
-            ref_basename: str = "ref",
-            mov_as_corepoints: bool = True,
-            use_subsampled_corepoints: int = 1) -> None:
-        self.folder = folder
-        self.mov_base = os.path.join(folder, mov_basename)
-        self.ref_base = os.path.join(folder, ref_basename)
-        self.mov_as_corepoints = mov_as_corepoints
-        self.use_subsampled_corepoints = use_subsampled_corepoints
-        os.makedirs(folder, exist_ok=True)
+    folder: str
+    mov_basename: str = "mov"
+    ref_basename: str = "ref"
+    mov_as_corepoints: bool = True
+    use_subsampled_corepoints: int = 1
 
-    @staticmethod
-    def _exists(p: str) -> bool:
-        return os.path.exists(p)
+    mov_base: Path = field(init=False)
+    ref_base: Path = field(init=False)
 
-    def _detect(self, base: str) -> tuple[str | None, str | None]:
-        """Gibt (kind, path) zurück, wobei kind in {'xyz','laslike','ply','obj','gpc'} oder None ist."""
-        xyz, las, laz, ply, obj, gpc = (
-            base + ".xyz",
-            base + ".las",
-            base + ".laz",
-            base + ".ply",
-            base + ".obj",
-            base + ".gpc",
-        )
-        if self._exists(xyz):
-            return "xyz", xyz
-        if self._exists(las) or self._exists(laz):
-            # egal ob .las oder .laz: beides ist 'laslike'
-            return "laslike", las if self._exists(las) else laz
-        if self._exists(ply):
-            return "ply", ply
-        if self._exists(obj):
-            return "obj", obj
-        if self._exists(gpc):
-            return "gpc", gpc
+    def __post_init__(self) -> None:
+        self.folder = Path(self.folder)
+        self.mov_base = self.folder / self.mov_basename
+        self.ref_base = self.folder / self.ref_basename
+        self.folder.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # helpers
+    def _detect(self, base: Path) -> tuple[str | None, Path | None]:
+        """Detect the file kind and its path for ``base``.
+
+        Returns
+        -------
+        tuple
+            ``(kind, path)`` where ``kind`` is one of ``{"xyz", "laslike",
+            "ply", "obj", "gpc"}`` or ``None`` if no file exists.
+        """
+
+        mapping = {
+            "xyz": base.with_suffix(".xyz"),
+            "las": base.with_suffix(".las"),
+            "laz": base.with_suffix(".laz"),
+            "ply": base.with_suffix(".ply"),
+            "obj": base.with_suffix(".obj"),
+            "gpc": base.with_suffix(".gpc"),
+        }
+
+        if mapping["xyz"].exists():
+            return "xyz", mapping["xyz"]
+        if mapping["las"].exists() or mapping["laz"].exists():
+            return "laslike", mapping["las"] if mapping["las"].exists() else mapping["laz"]
+        if mapping["ply"].exists():
+            return "ply", mapping["ply"]
+        if mapping["obj"].exists():
+            return "obj", mapping["obj"]
+        if mapping["gpc"].exists():
+            return "gpc", mapping["gpc"]
         return None, None
 
-    def _read_las_or_laz_to_xyz_array(self, path: str) -> np.ndarray:
+    def _read_las_or_laz_to_xyz_array(self, path: Path) -> np.ndarray:
         if laspy is None:
             raise RuntimeError("LAS/LAZ gefunden, aber 'laspy' ist nicht installiert.")
-        # Für .laz ggf. Backend nötig: pip install 'laspy[lazrs]'
         try:
-            las = laspy.read(path)
-        except ModuleNotFoundError as e:
-            raise RuntimeError("LAZ erkannt, bitte 'pip install \"laspy[lazrs]\"' installieren.") from e
+            las = laspy.read(str(path))
+        except ModuleNotFoundError as exc:  # pragma: no cover - dependency issue
+            raise RuntimeError(
+                "LAZ erkannt, bitte 'pip install \"laspy[lazrs]\"' installieren."
+            ) from exc
         return np.vstack([las.x, las.y, las.z]).T.astype(np.float64)
 
-    def _read_obj_to_xyz_array(self, path: str) -> np.ndarray:
-        """Parst ein einfaches Wavefront-OBJ mit 'v x y z'-Zeilen."""
+    def _read_obj_to_xyz_array(self, path: Path) -> np.ndarray:
         vertices: list[list[float]] = []
-        with open(path, "r", encoding="utf-8") as f:
-            for line in f:
+        with open(path, "r", encoding="utf-8") as handle:
+            for line in handle:
                 line = line.strip()
                 if line.startswith("v "):
                     parts = line.split()
@@ -81,86 +125,90 @@ class DataSource:
                         vertices.append([float(parts[1]), float(parts[2]), float(parts[3])])
         return np.asarray(vertices, dtype=np.float64)
 
-    def _read_gpc_to_xyz_array(self, path: str) -> np.ndarray:
-        """Lädt .gpc als einfache whitespace-separierte XYZ-Tabelle."""
+    def _read_gpc_to_xyz_array(self, path: Path) -> np.ndarray:
         return np.loadtxt(path, dtype=np.float64, usecols=(0, 1, 2))
 
-    def _ensure_xyz(self, base: str, detected: tuple[str | None, str | None]) -> str:
-        """Sorgt dafür, dass base.xyz existiert (konvertiert bei Bedarf)."""
+    def _ensure_xyz(self, base: Path, detected: tuple[str | None, Path | None]) -> Path:
+        """Ensure that an ``.xyz`` file exists for ``base``.
+
+        The method converts the detected file to ``.xyz`` when necessary and
+        returns the resulting path.
+        """
+
         kind, path = detected
-        xyz = base + ".xyz"
+        xyz = base.with_suffix(".xyz")
         if kind == "xyz" and path:
             return path
         if kind == "laslike" and path:
-            logging.info(f"[{base}] Konvertiere LAS/LAZ → XYZ …")
+            logging.info("[%s] Konvertiere LAS/LAZ → XYZ …", base)
             arr = self._read_las_or_laz_to_xyz_array(path)
             np.savetxt(xyz, arr, fmt="%.6f")
             return xyz
         if kind == "ply" and path:
             if PlyData is None:
                 raise RuntimeError("PLY gefunden, aber 'plyfile' ist nicht installiert.")
-            logging.info(f"[{base}] Konvertiere PLY → XYZ …")
-            ply = PlyData.read(path)
+            logging.info("[%s] Konvertiere PLY → XYZ …", base)
+            ply = PlyData.read(str(path))
             v = ply["vertex"]
             arr = np.vstack([v["x"], v["y"], v["z"]]).T.astype(np.float64)
             np.savetxt(xyz, arr, fmt="%.6f")
             return xyz
         if kind == "obj" and path:
-            logging.info(f"[{base}] Konvertiere OBJ → XYZ …")
+            logging.info("[%s] Konvertiere OBJ → XYZ …", base)
             arr = self._read_obj_to_xyz_array(path)
             np.savetxt(xyz, arr, fmt="%.6f")
             return xyz
         if kind == "gpc" and path:
-            logging.info(f"[{base}] Konvertiere GPC → XYZ …")
+            logging.info("[%s] Konvertiere GPC → XYZ …", base)
             arr = self._read_gpc_to_xyz_array(path)
             np.savetxt(xyz, arr, fmt="%.6f")
             return xyz
         raise FileNotFoundError(f"Fehlt: {base}.xyz/.las/.laz/.ply/.obj/.gpc")
 
-    def load_points(self) -> Tuple[py4dgeo.Epoch, py4dgeo.Epoch, np.ndarray]:
+    # ------------------------------------------------------------------
+    # public API
+    def load_points(self) -> Tuple[object, object, np.ndarray]:
+        """Load the moving and reference epochs and core points."""
+
+        if py4dgeo is None:  # pragma: no cover - handled via tests
+            raise RuntimeError("'py4dgeo' ist nicht installiert.")
+
         m_kind, m_path = self._detect(self.mov_base)
         r_kind, r_path = self._detect(self.ref_base)
 
-        # 1) beide xyz
         if m_kind == r_kind == "xyz":
             logging.info("Nutze py4dgeo.read_from_xyz")
-            mov, ref = py4dgeo.read_from_xyz(m_path, r_path)
-            logging.info(f"Mov Points: {mov.cloud.shape}")
-            logging.info(f"Ref Points: {ref.cloud.shape}")
-
-        # 2) beide laslike (las/laz gemischt erlaubt)
-        elif (m_kind == "laslike") and (r_kind == "laslike"):
+            mov, ref = py4dgeo.read_from_xyz(str(m_path), str(r_path))
+        elif m_kind == "laslike" and r_kind == "laslike":
             logging.info("Nutze py4dgeo.read_from_las (unterstützt .las und .laz)")
-            mov, ref = py4dgeo.read_from_las(m_path, r_path)
-            logging.info(f"Mov Points: {mov.cloud.shape}")
-            logging.info(f"Ref Points: {ref.cloud.shape}")
-
-        # 3) beide ply (nur wenn API vorhanden)
-        elif (m_kind == r_kind == "ply") and hasattr(py4dgeo, "read_from_ply"):
+            mov, ref = py4dgeo.read_from_las(str(m_path), str(r_path))
+        elif m_kind == r_kind == "ply" and hasattr(py4dgeo, "read_from_ply"):
             logging.info("Nutze py4dgeo.read_from_ply")
-            mov, ref = py4dgeo.read_from_ply(m_path, r_path)
-            logging.info(f"Mov Points: {mov.cloud.shape}")
-            logging.info(f"Ref Points: {ref.cloud.shape}")
-
-        # 4) Mischtypen → zu XYZ
+            mov, ref = py4dgeo.read_from_ply(str(m_path), str(r_path))
         else:
             m_xyz = self._ensure_xyz(self.mov_base, (m_kind, m_path))
             r_xyz = self._ensure_xyz(self.ref_base, (r_kind, r_path))
             logging.info("Mischtypen → konvertiert zu XYZ → py4dgeo.read_from_xyz")
-            mov, ref = py4dgeo.read_from_xyz(m_xyz, r_xyz)
-            logging.info(f"Mov Points: {mov.cloud.shape}")
-            logging.info(f"Ref Points: {ref.cloud.shape}")
+            mov, ref = py4dgeo.read_from_xyz(str(m_xyz), str(r_xyz))
 
-        # Corepoints: Nx3
         if self.mov_as_corepoints:
-            logging.info(f"Nutze mov als Corepoints und nutze Subsamling: {self.use_subsampled_corepoints}")
-            corepoints = mov.cloud[::self.use_subsampled_corepoints] if hasattr(mov, "cloud") else mov
-            logging.info(f"Corepoints: {corepoints.shape}")
+            logging.info(
+                "Nutze mov als Corepoints und nutze Subsamling: %s",
+                self.use_subsampled_corepoints,
+            )
+            corepoints = mov.cloud[:: self.use_subsampled_corepoints] if hasattr(mov, "cloud") else mov
         else:
-            logging.info(f"Nutze ref als Corepoints und nutze Subsamling: {self.use_subsampled_corepoints}")
-            corepoints = ref.cloud[::self.use_subsampled_corepoints] if hasattr(ref, "cloud") else ref
-            logging.info(f"Corepoints: {corepoints.shape}")
+            logging.info(
+                "Nutze ref als Corepoints und nutze Subsamling: %s",
+                self.use_subsampled_corepoints,
+            )
+            corepoints = ref.cloud[:: self.use_subsampled_corepoints] if hasattr(ref, "cloud") else ref
 
         if not isinstance(corepoints, np.ndarray):
             raise TypeError("Unerwarteter Typ für corepoints; erwarte np.ndarray (Nx3).")
+
         return mov, ref, corepoints
+
+
+__all__ = ["DataSource"]
+

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1,0 +1,66 @@
+"""Tests for the :mod:`datasource.datasource` module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import datasource.datasource as ds_module
+
+
+class DummyEpoch:
+    """Simple stand-in for :class:`py4dgeo.Epoch`."""
+
+    def __init__(self, arr: np.ndarray) -> None:
+        self.cloud = arr
+
+
+class DummyPy4DGeo:
+    @staticmethod
+    def read_from_xyz(m_path: str, r_path: str):  # type: ignore[override]
+        mov_arr = np.loadtxt(m_path)
+        ref_arr = np.loadtxt(r_path)
+        return DummyEpoch(mov_arr), DummyEpoch(ref_arr)
+
+
+def test_detect_xyz(tmp_path: Path) -> None:
+    folder = tmp_path / "data"
+    folder.mkdir()
+    (folder / "mov.xyz").write_text("0 0 0\n")
+
+    ds = ds_module.DataSource(str(folder))
+    kind, path = ds._detect(ds.mov_base)
+
+    assert kind == "xyz"
+    assert path == folder / "mov.xyz"
+
+
+def test_ensure_xyz_from_gpc(tmp_path: Path) -> None:
+    gpc_path = tmp_path / "mov.gpc"
+    gpc_path.write_text("1 2 3\n4 5 6\n")
+    ds = ds_module.DataSource(str(tmp_path))
+
+    xyz_path = ds._ensure_xyz(ds.mov_base, ("gpc", gpc_path))
+
+    assert xyz_path.exists()
+    data = np.loadtxt(xyz_path)
+    assert data.shape == (2, 3)
+
+
+def test_load_points_xyz(tmp_path: Path, monkeypatch) -> None:
+    mov = np.array([[0, 0, 0], [1, 1, 1]], dtype=float)
+    ref = np.array([[0, 0, 0], [2, 2, 2]], dtype=float)
+    np.savetxt(tmp_path / "mov.xyz", mov, fmt="%.6f")
+    np.savetxt(tmp_path / "ref.xyz", ref, fmt="%.6f")
+
+    monkeypatch.setattr(ds_module, "py4dgeo", DummyPy4DGeo)
+
+    ds = ds_module.DataSource(str(tmp_path))
+    mov_epoch, ref_epoch, corepoints = ds.load_points()
+
+    assert np.allclose(mov_epoch.cloud, mov)
+    assert np.allclose(ref_epoch.cloud, ref)
+    assert np.allclose(corepoints, mov)

--- a/tests/test_exclude_outliers.py
+++ b/tests/test_exclude_outliers.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from services.exclude_outliers import OutlierResult, exclude_outliers
+
+
+def _write_distances(path):
+    data = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.1],
+            [0.0, 0.0, 0.0, 0.2],
+            [0.0, 0.0, 0.0, 0.3],
+            [0.0, 0.0, 0.0, -0.1],
+            [0.0, 0.0, 0.0, 0.15],
+            [0.0, 0.0, 0.0, 5.0],
+            [0.0, 0.0, 0.0, -5.0],
+            [0.0, 0.0, 0.0, np.nan],
+        ]
+    )
+    np.savetxt(path, data, header="x y z distance")
+
+
+def _assert_result(res: OutlierResult) -> None:
+    assert res.inliers.shape[0] == 6
+    assert res.outliers.shape[0] == 2
+    assert set(np.round(res.outliers[:, 3])) == {5.0, -5.0}
+
+
+def test_exclude_outliers_methods(tmp_path):
+    file_path = tmp_path / "distances.txt"
+    _write_distances(file_path)
+
+    for method, factor in [("rmse", 1.0), ("iqr", 3.0), ("std", 1.0), ("nmad", 3.0)]:
+        res = exclude_outliers(str(file_path), method, factor)
+        _assert_result(res)
+
+        inlier_file = tmp_path / f"distances_inlier_{method}.txt"
+        outlier_file = tmp_path / f"distances_outlier_{method}.txt"
+        assert inlier_file.exists()
+        assert outlier_file.exists()
+

--- a/tests/test_param_estimator.py
+++ b/tests/test_param_estimator.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+from orchestration.strategies import ScaleScan
+from services.param_estimator import ParamEstimator
+
+
+class DummyStrategy:
+    def __init__(self, scans):
+        self.scans = scans
+        self.called_with = None
+
+    def scan(self, points, avg_spacing):
+        self.called_with = (points, avg_spacing)
+        return self.scans
+
+
+def test_estimate_min_spacing_and_scan(tmp_path):
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ]
+    )
+
+    scans = [
+        ScaleScan(scale=1.0, valid_normals=10, mean_population=0, roughness=0.1, coverage=1.0, mean_lambda3=0.01),
+    ]
+    strategy = DummyStrategy(scans)
+    estimator = ParamEstimator(strategy=strategy, k_neighbors=2)
+
+    spacing = estimator.estimate_min_spacing(points)
+    assert spacing == pytest.approx(1.0, abs=0.1)
+
+    result_scans = estimator.scan_scales(points, spacing)
+    assert result_scans is scans
+    assert strategy.called_with == (points, spacing)
+
+
+def test_select_scales():
+    scans = [
+        ScaleScan(scale=1.0, valid_normals=10, mean_population=0, roughness=0.1, coverage=1.0, mean_lambda3=0.01),
+        ScaleScan(scale=2.0, valid_normals=8, mean_population=0, roughness=0.05, coverage=1.0, mean_lambda3=0.02),
+    ]
+    normal, projection = ParamEstimator.select_scales(scans)
+    assert normal == pytest.approx(2.0)
+    assert projection == pytest.approx(2.0)
+


### PR DESCRIPTION
## Summary
- restructure outlier removal into a typed API with clear load/process/save steps
- convert parameter estimator into a dataclass and streamline scale selection logic
- add unit tests covering outlier detection and parameter estimation workflows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4876828f88323892ffd6c19acebdc