### PR TITLE
Refactor outlier handling and add runner tests

### DIFF
--- a/services/exclude_outliers.py
+++ b/services/exclude_outliers.py
@@ -1,21 +1,22 @@
-"""Utilities for excluding outliers from M3C2 distance files.
-
-The original implementation mixed reading, processing and writing logic in a
-single function.  This module now separates these concerns and exposes a small
-typed API that is easier to test.  Distances are loaded from a file, processed
-into inliers/outliers and can then optionally be written back to disk.
-"""
+"""Utilities for excluding outliers from M3C2 distance files."""
 
 from dataclasses import dataclass
 import logging
-import os
 from pathlib import Path
 from typing import Tuple
 
 import numpy as np
 
-
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OutlierConfig:
+    """Configuration for outlier detection."""
+
+    file_path: str
+    method: str
+    outlier_multiplicator: float = 3.0
 
 
 @dataclass
@@ -26,87 +27,104 @@ class OutlierResult:
     outliers: np.ndarray
 
 
-def _load_distances(file_path: str) -> np.ndarray:
-    """Load distance rows ignoring the first header line."""
+class OutlierDetector:
+    """Perform outlier detection based on a configuration."""
 
-    return np.loadtxt(file_path, skiprows=1)
+    def __init__(self, config: OutlierConfig) -> None:
+        self.config = config
 
+    @staticmethod
+    def _detect_outlier_mask(
+        distances: np.ndarray, method: str, factor: float
+    ) -> Tuple[np.ndarray, float]:
+        """Return a boolean mask of outliers and the threshold used."""
 
-def _detect_outlier_mask(distances: np.ndarray, method: str, factor: float) -> Tuple[np.ndarray, float]:
-    """Return a boolean mask of outliers and the threshold used."""
+        if method == "rmse":
+            metric = float(np.sqrt(np.mean(distances**2)))
+            threshold = factor * metric
+            mask = np.abs(distances) > threshold
+            logger.info("[Exclude Outliers] RMS: %.6f", metric)
+            logger.info("[Exclude Outliers] Outlier-Schwelle: %.6f", threshold)
+        elif method == "iqr":
+            q1, q3 = np.percentile(distances, [25, 75])
+            metric = q3 - q1
+            lower = q1 - 1.5 * metric
+            upper = q3 + 1.5 * metric
+            mask = (distances < lower) | (distances > upper)
+            threshold = float(max(abs(lower), abs(upper)))
+            logger.info("[Exclude Outliers] IQR: %.6f", metric)
+            logger.info(
+                "[Exclude Outliers] Outlier-Schwellen: %.6f bis %.6f", lower, upper
+            )
+        elif method == "std":
+            mean = float(np.mean(distances))
+            metric = float(np.std(distances))
+            threshold = factor * metric
+            mask = np.abs(distances - mean) > threshold
+            logger.info("[Exclude Outliers] STD: %.6f", metric)
+            logger.info("[Exclude Outliers] Outlier-Schwelle: %.6f", threshold)
+        elif method == "nmad":
+            median = float(np.median(distances))
+            metric = 1.4826 * float(np.median(np.abs(distances - median)))
+            threshold = factor * metric
+            mask = np.abs(distances - median) > threshold
+        else:
+            raise ValueError("Unknown outlier detection method")
 
-    if method == "rmse":
-        metric = float(np.sqrt(np.mean(distances**2)))
-        threshold = factor * metric
-        mask = np.abs(distances) > threshold
-        logger.info("[Exclude Outliers] RMS: %.6f", metric)
-        logger.info("[Exclude Outliers] Outlier-Schwelle: %.6f", threshold)
-    elif method == "iqr":
-        q1, q3 = np.percentile(distances, [25, 75])
-        metric = q3 - q1
-        lower = q1 - 1.5 * metric
-        upper = q3 + 1.5 * metric
-        mask = (distances < lower) | (distances > upper)
-        threshold = float(max(abs(lower), abs(upper)))
-        logger.info("[Exclude Outliers] IQR: %.6f", metric)
-        logger.info("[Exclude Outliers] Outlier-Schwellen: %.6f bis %.6f", lower, upper)
-    elif method == "std":
-        mean = float(np.mean(distances))
-        metric = float(np.std(distances))
-        threshold = factor * metric
-        mask = np.abs(distances - mean) > threshold
-        logger.info("[Exclude Outliers] STD: %.6f", metric)
-        logger.info("[Exclude Outliers] Outlier-Schwelle: %.6f", threshold)
-    elif method == "nmad":
-        median = float(np.median(distances))
-        metric = 1.4826 * float(np.median(np.abs(distances - median)))
-        threshold = factor * metric
-        mask = np.abs(distances - median) > threshold
-    else:
-        raise ValueError("Unknown outlier detection method")
+        return mask, threshold
 
-    return mask, threshold
+    def _save(self, result: OutlierResult) -> None:
+        base = Path(self.config.file_path).with_suffix("")
+        inlier_path = f"{base}_inlier_{self.config.method}.txt"
+        outlier_path = f"{base}_outlier_{self.config.method}.txt"
+        header = "x y z distance"
+        np.savetxt(inlier_path, result.inliers, fmt="%.6f", header=header)
+        np.savetxt(outlier_path, result.outliers, fmt="%.6f", header=header)
+        logger.info("[Exclude Outliers] Inlier gespeichert: %s", inlier_path)
+        logger.info("[Exclude Outliers] Outlier gespeichert: %s", outlier_path)
+
+    def run(self) -> OutlierResult:
+        """Load distances, split into inliers/outliers and write results."""
+
+        distances_all = np.loadtxt(self.config.file_path, skiprows=1)
+        valid_mask = ~np.isnan(distances_all[:, 3])
+        distances_valid = distances_all[valid_mask]
+        mask, _ = self._detect_outlier_mask(
+            distances_valid[:, 3], self.config.method, self.config.outlier_multiplicator
+        )
+        result = OutlierResult(
+            inliers=distances_valid[~mask], outliers=distances_valid[mask]
+        )
+
+        self._save(result)
+
+        logger.info("[Exclude Outliers] Gesamt: %d", distances_all.shape[0])
+        logger.info(
+            "[Exclude Outliers] NaN: %d",
+            int(np.isnan(distances_all[:, 3]).sum()),
+        )
+        logger.info(
+            "[Exclude Outliers] Valid (ohne NaN): %d", distances_valid.shape[0]
+        )
+        logger.info("[Exclude Outliers] Methode: %s", self.config.method)
+        logger.info("[Exclude Outliers] Outlier: %d", result.outliers.shape[0])
+        logger.info("[Exclude Outliers] Inlier: %d", result.inliers.shape[0])
+
+        return result
 
 
 def exclude_outliers(
-    file_path: str,
-    method: str,
-    outlier_multiplicator: float = 3.0,
+    file_path: str, method: str, outlier_multiplicator: float = 3.0
 ) -> OutlierResult:
-    """Split the given distance file into inliers and outliers.
+    """Convenience wrapper around :class:`OutlierDetector`."""
 
-    Parameters
-    ----------
-    file_path:
-        Path to a ``python_*_m3c2_distances_coordinates.txt`` file.
-    method:
-        Outlier detection method (``rmse``, ``iqr``, ``std`` or ``nmad``).
-    outlier_multiplicator:
-        Factor applied to the respective metric.
-    """
+    config = OutlierConfig(
+        file_path=file_path,
+        method=method,
+        outlier_multiplicator=outlier_multiplicator,
+    )
+    detector = OutlierDetector(config)
+    return detector.run()
 
-    distances_all = _load_distances(file_path)
-    valid_mask = ~np.isnan(distances_all[:, 3])
-    distances_valid = distances_all[valid_mask]
-    mask, _ = _detect_outlier_mask(distances_valid[:, 3], method, outlier_multiplicator)
 
-    result = OutlierResult(inliers=distances_valid[~mask], outliers=distances_valid[mask])
-
-    base = Path(file_path).with_suffix("")
-    inlier_path = f"{base}_inlier_{method}.txt"
-    outlier_path = f"{base}_outlier_{method}.txt"
-    header = "x y z distance"
-    np.savetxt(inlier_path, result.inliers, fmt="%.6f", header=header)
-    np.savetxt(outlier_path, result.outliers, fmt="%.6f", header=header)
-
-    logger.info("[Exclude Outliers] Gesamt: %d", distances_all.shape[0])
-    logger.info("[Exclude Outliers] NaN: %d", int(np.isnan(distances_all[:, 3]).sum()))
-    logger.info("[Exclude Outliers] Valid (ohne NaN): %d", distances_valid.shape[0])
-    logger.info("[Exclude Outliers] Methode: %s", method)
-    logger.info("[Exclude Outliers] Outlier: %d", result.outliers.shape[0])
-    logger.info("[Exclude Outliers] Inlier: %d", result.inliers.shape[0])
-    logger.info("[Exclude Outliers] Inlier gespeichert: %s", inlier_path)
-    logger.info("[Exclude Outliers] Outlier gespeichert: %s", outlier_path)
-
-    return result
-
+__all__ = ["OutlierConfig", "OutlierResult", "OutlierDetector", "exclude_outliers"]

--- a/tests/test_exclude_outliers.py
+++ b/tests/test_exclude_outliers.py
@@ -1,6 +1,11 @@
 import numpy as np
 
-from services.exclude_outliers import OutlierResult, exclude_outliers
+from services.exclude_outliers import (
+    OutlierConfig,
+    OutlierDetector,
+    OutlierResult,
+    exclude_outliers,
+)
 
 
 def _write_distances(path):
@@ -38,4 +43,16 @@ def test_exclude_outliers_methods(tmp_path):
         outlier_file = tmp_path / f"distances_outlier_{method}.txt"
         assert inlier_file.exists()
         assert outlier_file.exists()
+
+
+def test_outlier_detector_class(tmp_path):
+    file_path = tmp_path / "distances.txt"
+    _write_distances(file_path)
+
+    config = OutlierConfig(
+        file_path=str(file_path), method="rmse", outlier_multiplicator=1.0
+    )
+    detector = OutlierDetector(config)
+    res = detector.run()
+    _assert_result(res)
 

--- a/tests/test_m3c2_runner.py
+++ b/tests/test_m3c2_runner.py
@@ -1,0 +1,39 @@
+import sys
+import types
+import importlib
+import numpy as np
+
+
+def test_m3c2_runner(monkeypatch):
+    called = {}
+
+    class DummyM3C2:
+        def __init__(self, **kwargs):
+            called['params'] = (
+                kwargs['epochs'],
+                kwargs['corepoints'],
+                kwargs['cyl_radius'],
+                kwargs['normal_radii'],
+            )
+
+        def run(self):
+            return np.array([1.0]), np.array([0.1])
+
+    dummy_py4dgeo = types.SimpleNamespace(M3C2=DummyM3C2)
+    monkeypatch.setitem(sys.modules, 'py4dgeo', dummy_py4dgeo)
+
+    runner_module = importlib.reload(
+        importlib.import_module('orchestration.m3c2_runner')
+    )
+
+    mov = object()
+    ref = object()
+    corepoints = np.array([[0.0, 0.0, 0.0]])
+
+    distances, uncertainties = runner_module.M3C2Runner.run(
+        mov, ref, corepoints, normal=0.5, projection=1.0
+    )
+
+    assert np.allclose(distances, [1.0])
+    assert np.allclose(uncertainties, [0.1])
+    assert called['params'] == ((mov, ref), corepoints, 1.0, [0.5])


### PR DESCRIPTION
## Summary
- introduce `OutlierConfig` dataclass and `OutlierDetector` class to separate configuration, processing and persistence for outlier removal
- expose `exclude_outliers` as a thin wrapper around the new class
- add unit tests for the outlier detector and a mocked end-to-end test for `M3C2Runner`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48b75bd8883239e536395604d3a03