### PR TITLE
Improve documentation for orchestration modules

### DIFF
--- a/orchestration/__init__.py
+++ b/orchestration/__init__.py
@@ -1,0 +1,8 @@
+"""Utilities for coordinating the M3C2 processing pipeline.
+
+This package groups together orchestrator classes that tie the various
+services and configuration objects into a runnable pipeline for the M3C2
+workflow.  The modules here expose high-level interfaces for batch
+processing, parameter scanning and execution of the core algorithm.
+"""
+

--- a/orchestration/batch_orchestrator.py
+++ b/orchestration/batch_orchestrator.py
@@ -1,4 +1,10 @@
 from __future__ import annotations
+"""High level orchestration for running the complete M3C2 workflow.
+
+The :class:`BatchOrchestrator` coordinates configuration handling, parameter
+estimation, execution of the core algorithm and subsequent analysis steps.
+"""
+
 import logging
 import os
 import time
@@ -17,7 +23,17 @@ logger = logging.getLogger(__name__)
 
 
 class BatchOrchestrator:
-    """Run the full M3C2 pipeline for a collection of configurations."""
+    """Run the full M3C2 pipeline for a collection of configurations.
+
+    Parameters
+    ----------
+    configs : list[PipelineConfig]
+        Collection of configuration objects to process.
+    sample_size : int, optional
+        Number of core points to sample when estimating scales.
+    output_format : str
+        Format for statistical outputs, ``"excel"`` or ``"json"``.
+    """
 
     def __init__(
         self,
@@ -25,26 +41,62 @@ class BatchOrchestrator:
         sample_size: int | None = None,
         output_format: str = "excel",
     ) -> None:
+        """Create a new orchestrator instance.
+
+        Parameters
+        ----------
+        configs : list[PipelineConfig]
+            Configurations describing each job to run.
+        sample_size : int, optional
+            Number of core points used during scale estimation.
+        output_format : str
+            Output format for statistics, ``"excel"`` or ``"json"``.
+        """
         self.configs = configs
         self.sample_size = sample_size
         self.output_format = output_format.lower()
+        # Strategy object used for scanning normal scales
         self.strategy = RadiusScanStrategy(sample_size=sample_size)
 
+        # Log basic information about the incoming batch
         logger.info("=== BatchOrchestrator initialisiert ===")
         logger.info("Konfigurationen: %d Jobs", len(self.configs))
 
 
-    # Kleiner Helfer für konsistente Dateinamen
+    # Small helper to create consistent file name tags
     @staticmethod
     def _run_tag(cfg: PipelineConfig) -> str:
+        """Return a concise tag representing the moving and reference files.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration for the current job.
+
+        Returns
+        -------
+        str
+            Combination of moving and reference filenames.
+        """
         return f"{cfg.filename_mov}-{cfg.filename_ref}"
     
     def run_all(self) -> None:
-        """Run the pipeline for each configured dataset."""
+        """Run the pipeline for each configured dataset.
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        Any exception raised during processing of a single job is caught and
+        logged so that subsequent jobs can continue.
+        """
         if not self.configs:
             logger.warning("Keine Konfigurationen – nichts zu tun.")
             return
 
+        # Process each configuration in sequence
         for cfg in self.configs:
             try:
                 self._run_single(cfg)
@@ -52,6 +104,22 @@ class BatchOrchestrator:
                 logger.exception("[Job] Fehler in Job '%s' (Version %s)", cfg.folder_id, cfg.filename_ref)
 
     def _run_single(self, cfg: PipelineConfig) -> None:
+        """Execute the pipeline for a single configuration.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration for the dataset to process.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        Exception
+            Any exception from internal steps is caught and logged.
+        """
         logger.info(
             "%s, %s, %s, %s",
             cfg.folder_id,
@@ -61,14 +129,16 @@ class BatchOrchestrator:
         )
         start = time.perf_counter()
 
+        # Load input data and determine core points
         ds, mov, ref, corepoints = self._load_data(cfg)
 
         if cfg.process_python_CC == "python" and not cfg.only_stats:
-            # Nur ausführen, wenn nicht nur Statistiken berechnet werden sollen
+            # Run M3C2 only when full processing (beyond statistics) is requested
             out_base = ds.folder
             tag = self._run_tag(cfg)
             normal = projection = np.nan
             if cfg.use_existing_params:
+                # Reuse previously estimated parameters if available
                 params_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_params.txt")
                 normal, projection = StatisticsService._load_params(params_path)
 
@@ -84,29 +154,32 @@ class BatchOrchestrator:
                         "[Params] keine vorhandenen Parameter gefunden, berechne neu",
                     )
             if np.isnan(normal) or np.isnan(projection):
+                # Estimate optimal scales and persist them for later runs
                 normal, projection = self._determine_scales(cfg, corepoints)
                 self._save_params(cfg, normal, projection, out_base)
             distances, _ = self._run_m3c2(
                 cfg, mov, ref, corepoints, normal, projection, out_base
             )
 
-            # all distances incl. outliers
+            # Visualise distances including those flagged as outliers
             self._generate_visuals(cfg, mov, distances, out_base)
 
         try:
-            # Generate distance txts excluding outliers & outliers only for outlier .ply visualisation
+            # Generate distance files excluding outliers for further analysis
             logger.info("[Outlier] Entferne Ausreißer für %s", cfg.folder_id)
             self._exclude_outliers(cfg, ds.folder)
         except Exception:
             logger.exception("Fehler beim Entfernen von Ausreißern")
 
         try:
+            # Create coloured point clouds showing outliers and inliers
             logger.info("[Outlier] Erzeuge .ply Dateien für Outliers / Inliers …")
             self._generate_clouds_outliers(cfg, ds.folder)
         except Exception:
             logger.exception("Fehler beim Erzeugen von .ply Dateien für Ausreißer / Inlier")
 
         try:
+            # Compute summary statistics for the processed dataset
             self._compute_statistics(cfg, ref)
         except Exception:
             logger.exception("Fehler bei der Berechnung der Statistik")
@@ -114,7 +187,21 @@ class BatchOrchestrator:
         logger.info("[Job] %s abgeschlossen in %.3fs", cfg.folder_id, time.perf_counter() - start)
 
     def _load_data(self, cfg: PipelineConfig) -> Tuple[DataSource, object, object, object]:
+        """Load point cloud data and core points according to the configuration.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration specifying file names and loading options.
+
+        Returns
+        -------
+        tuple
+            ``(DataSource, moving, reference, corepoints)`` where ``moving`` and
+            ``reference`` are objects understood by downstream services.
+        """
         t0 = time.perf_counter()
+        # Create a data source that knows how to load the required clouds
         ds = DataSource(
             cfg.folder_id,
             cfg.filename_mov,
@@ -134,7 +221,22 @@ class BatchOrchestrator:
         return ds, mov, ref, corepoints
 
     def _determine_scales(self, cfg: PipelineConfig, corepoints) -> Tuple[float, float]:
+        """Determine suitable normal and projection scales.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration possibly providing override values.
+        corepoints : array-like
+            Points used for scale estimation.
+
+        Returns
+        -------
+        tuple of float
+            Chosen normal and projection scales.
+        """
         if cfg.normal_override is not None and cfg.proj_override is not None:
+            # Respect user-specified override parameters
             normal, projection = cfg.normal_override, cfg.proj_override
             logger.info("[Scales] Overrides verwendet: normal=%.6f, proj=%.6f", normal, projection)
             return normal, projection
@@ -148,6 +250,7 @@ class BatchOrchestrator:
         logger.info("[Scan] %d Skalen evaluiert | %.3fs", len(scans), time.perf_counter() - t0)
 
         if scans:
+            # Log a few of the most promising scales for debugging
             top_valid = sorted(scans, key=lambda s: s.valid_normals, reverse=True)[:5]
             logger.debug("  Top(valid_normals): %s", [(round(s.scale, 6), int(s.valid_normals)) for s in top_valid])
             top_smooth = sorted(scans, key=lambda s: (np.nan_to_num(s.roughness, nan=np.inf)))[:5]
@@ -159,6 +262,19 @@ class BatchOrchestrator:
         return normal, projection
 
     def _save_params(self, cfg: PipelineConfig, normal: float, projection: float, out_base: str) -> None:
+        """Persist determined scale parameters to disk.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration for naming the output file.
+        normal : float
+            Chosen normal scale.
+        projection : float
+            Chosen projection scale.
+        out_base : str
+            Directory where the parameter file should be written.
+        """
         os.makedirs(out_base, exist_ok=True)
         tag = self._run_tag(cfg)
         params_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_params.txt")
@@ -166,9 +282,32 @@ class BatchOrchestrator:
             f.write(f"NormalScale={normal}\nSearchScale={projection}\n")
         logger.info("[Params] gespeichert: %s", params_path)
 
+
     def _run_m3c2(self, cfg: PipelineConfig, mov, ref, corepoints, normal: float, projection: float, out_base: str,
     ) -> Tuple[np.ndarray, np.ndarray]:
-        
+        """Run the M3C2 algorithm and persist results to disk.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Current job configuration.
+        mov, ref : object
+            Moving and reference point clouds or epochs.
+        corepoints : array-like
+            Core points at which distances are evaluated.
+        normal : float
+            Normal scale to use in the computation.
+        projection : float
+            Projection scale to use in the computation.
+        out_base : str
+            Directory where result files are written.
+
+        Returns
+        -------
+        tuple of ndarray
+            Arrays of distances and their associated uncertainties.
+        """
+
         tag = self._run_tag(cfg)
 
         t0 = time.perf_counter()
@@ -183,12 +322,10 @@ class BatchOrchestrator:
         np.savetxt(dists_path, distances, fmt="%.6f")
         logger.info("[Run] Distanzen gespeichert: %s (%d Werte, %.2f%% NaN)", dists_path, n, 100.0 * nan_share)
 
-
-        # NEU: Speichere XYZ-Koordinaten + Distanz in einer Datei
-
-
+        # Store XYZ coordinates alongside the computed distances
         coords_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_distances_coordinates.txt")
 
+        # Handle both Epoch objects (with .cloud) and raw numpy arrays
         if hasattr(mov, "cloud"):
             xyz = np.asarray(mov.cloud)
         else:
@@ -201,8 +338,6 @@ class BatchOrchestrator:
         else:
             logger.warning(f"[Run] Anzahl Koordinaten stimmt nicht mit Distanzen überein: {xyz.shape[0]} vs {distances.shape[0]}")
 
-
-
         uncert_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_uncertainties.txt")
         np.savetxt(uncert_path, uncertainties, fmt="%.6f")
         logger.info("[Run] Unsicherheiten gespeichert: %s", uncert_path)
@@ -210,6 +345,15 @@ class BatchOrchestrator:
         return distances, uncertainties
 
     def _exclude_outliers(self, cfg: PipelineConfig, out_base: str) -> None:
+        """Remove statistical outliers from the distance results.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration containing outlier detection settings.
+        out_base : str
+            Directory where distance files are stored.
+        """
         tag = self._run_tag(cfg)
         exclude_outliers(
             data_folder=out_base,
@@ -218,7 +362,17 @@ class BatchOrchestrator:
             outlier_multiplicator=cfg.outlier_multiplicator
         )
 
+
     def _compute_statistics(self, cfg: PipelineConfig, ref) -> None:
+        """Compute and export statistical summaries for the run.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration describing which statistics to compute.
+        ref : object
+            Reference cloud used for statistics depending on mode.
+        """
         tag = self._run_tag(cfg)
         if cfg.stats_singleordistance == "distance":
             logger.info(f"[Stats on Distance] Berechne M3C2-Statistiken {cfg.folder_id},{cfg.filename_ref} …")
@@ -243,7 +397,7 @@ class BatchOrchestrator:
 
         if cfg.stats_singleordistance == "single":
             logger.info(
-                f"[Stats on SingleClouds] Berechne M3C2-Statistiken {cfg.folder_id},{cfg.filename_ref} …"
+                f"[Stats on SingleClouds] Berechne M3C2-Statistiken {cfg.folder_id},{cfg.filename_ref} …",
             )
 
             if self.output_format == "excel":
@@ -263,6 +417,19 @@ class BatchOrchestrator:
             )
 
     def _generate_visuals(self, cfg: PipelineConfig, mov, distances: np.ndarray, out_base: str) -> None:
+        """Create graphical and point cloud representations of results.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration for file naming.
+        mov : object
+            Moving point cloud containing coordinates.
+        distances : ndarray
+            Array of M3C2 distances corresponding to the moving cloud.
+        out_base : str
+            Directory to place the generated files in.
+        """
         logger.info("[Visual] Erzeuge Visualisierungen …")
         tag = self._run_tag(cfg)
         os.makedirs(out_base, exist_ok=True)
@@ -284,6 +451,15 @@ class BatchOrchestrator:
             logger.warning("[Visual] Export valid-only übersprungen: %s", exc)
 
     def _generate_clouds_outliers(self, cfg: PipelineConfig, out_base: str) -> None:
+        """Create coloured point clouds for inliers and outliers.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration providing file naming and outlier settings.
+        out_base : str
+            Directory where output files are written.
+        """
         logger.info("[Visual] Erzeuge .ply Dateien für Outliers / Inliers …")
         os.makedirs(out_base, exist_ok=True)
         tag = self._run_tag(cfg)

--- a/orchestration/m3c2_runner.py
+++ b/orchestration/m3c2_runner.py
@@ -1,3 +1,11 @@
+"""Thin wrapper around the :mod:`py4dgeo` M3C2 implementation.
+
+The runner hides the instantiation details of the external library and
+returns only the computed distances and uncertainties.  It exists mainly to
+isolate direct dependencies on :mod:`py4dgeo` from higher level orchestration
+code.
+"""
+
 from __future__ import annotations
 import numpy as np
 import py4dgeo
@@ -5,6 +13,8 @@ from typing import Tuple
 
 
 class M3C2Runner:
+    """Execute the M3C2 algorithm for a pair of point clouds."""
+
     @staticmethod
     def run(
         mov: py4dgeo.Epoch,
@@ -13,6 +23,32 @@ class M3C2Runner:
         normal: float,
         projection: float,
     ) -> Tuple[np.ndarray, np.ndarray]:
+        """Run the M3C2 algorithm.
+
+        Parameters
+        ----------
+        mov, ref : :class:`py4dgeo.Epoch`
+            The moving and reference epochs to compare.
+        corepoints : ndarray
+            Array of core point coordinates where distances are evaluated.
+        normal : float
+            Normal scale used for surface orientation estimation.
+        projection : float
+            Projection radius used for distance computation.
+
+        Returns
+        -------
+        distances : ndarray
+            Signed distances for each core point.
+        uncertainties : ndarray
+            Uncertainty estimate for each distance value.
+
+        Raises
+        ------
+        Exception
+            Propagated from :mod:`py4dgeo` if the computation fails.
+        """
+        # Create the py4dgeo object that performs the actual computation
         m3c2 = py4dgeo.M3C2(
             epochs=(mov, ref),
             corepoints=corepoints,


### PR DESCRIPTION
## Summary
- document orchestration package and batch orchestrator pipeline
- add detailed explanations for strategy and runner helpers
- clarify orchestration utilities with inline comments and docstrings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b49740f3b48323aee25b1eee2d28cd