### PR TITLE
Refactor DataSource.load_points for clarity

### DIFF
--- a/m3c2/config/datasource_config.py
+++ b/m3c2/config/datasource_config.py
@@ -12,3 +12,4 @@ class DataSourceConfig:
     ref_basename: str = "ref"
     mov_as_corepoints: bool = True
     use_subsampled_corepoints: int = 1
+

--- a/m3c2/io/datasource.py
+++ b/m3c2/io/datasource.py
@@ -12,22 +12,34 @@ reference epoch and the core points as NumPy arrays.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Tuple
+
 import numpy as np
 import py4dgeo
 from plyfile import PlyData
 import laspy
-import config.datasource_config as cfg
-from .format_handler import read_xyz, read_las, read_ply, read_obj, read_gpc
+
+from m3c2.config.datasource_config import DataSourceConfig
+from .format_handler import read_las, read_ply, read_obj, read_gpc
 
 
 @dataclass
 class DataSource:
     """Class for loading point cloud pairs from various file formats."""
 
-    config: cfg.DataSourceConfig
+    config: DataSourceConfig
+
+    # ------------------------------------------------------------------
+    # path helpers
+    @property
+    def mov_base(self) -> Path:
+        return Path(self.config.folder) / self.config.mov_basename
+
+    @property
+    def ref_base(self) -> Path:
+        return Path(self.config.folder) / self.config.ref_basename
 
     def _detect(self, base: Path) -> tuple[str | None, Path | None]:
         
@@ -119,79 +131,59 @@ class DataSource:
 
     # ------------------------------------------------------------------
     # public API
-    def load_points(self, config) -> Tuple[object, object, np.ndarray]:
-        """Load the moving and reference epochs and derive core points.
+    def load_points(self) -> Tuple[object, object, np.ndarray]:
+        """Load the moving and reference epochs and derive core points."""
 
-        Returns
-        -------
-        tuple
-            ``(mov, ref, corepoints)`` where ``mov`` and ``ref`` are the
-            objects returned by :mod:`py4dgeo` and ``corepoints`` is an
-            ``np.ndarray`` of shape ``(N, 3)``.
-
-        Raises
-        ------
-        RuntimeError
-            If :mod:`py4dgeo` is not available.
-        TypeError
-            If the derived core points are not an ``np.ndarray``.
-        """
-
-        if py4dgeo is None: 
+        if py4dgeo is None:
             raise RuntimeError("'py4dgeo' ist nicht installiert.")
 
-        # Determine the available file types for moving and reference epochs
-        m_kind, m_path = self._detect(self.config.mov_basename)
-        r_kind, r_path = self._detect(self.config.ref_basename)
-
-        # Choose the appropriate py4dgeo reader based on detected types
-        if m_kind == r_kind == "xyz":
-            logging.info("Nutze py4dgeo.read_from_xyz")
-            mov, ref = py4dgeo.read_from_xyz(str(m_path), str(r_path))
-
-        elif m_kind == "laslike" and r_kind == "laslike":
-            logging.info("Nutze py4dgeo.read_from_las (unterstützt .las und .laz)")
-            mov, ref = py4dgeo.read_from_las(str(m_path), str(r_path))
-
-        elif m_kind == r_kind == "ply" and hasattr(py4dgeo, "read_from_ply"):
-            logging.info("Nutze py4dgeo.read_from_ply")
-            mov, ref = read_ply(str(m_path), str(r_path))
-
-        else:
-            # Convert heterogeneous types to XYZ and use the generic reader
-            m_xyz = self._ensure_xyz(self.config.mov_basename, (m_kind, m_path))
-            r_xyz = self._ensure_xyz(self.config.ref_basename, (r_kind, r_path))
-
-            logging.info("Mischtypen → konvertiert zu XYZ → py4dgeo.read_from_xyz")
-
-            mov, ref = py4dgeo.read_from_xyz(str(m_xyz), str(r_xyz))
-
-        # Extract core points from the configured epoch, optionally subsampled
-        if self.config.mov_as_corepoints:
-            logging.info(
-                "Nutze mov als Corepoints und nutze Subsamling: %s",
-                self.config.use_subsampled_corepoints,
-            )
-            corepoints = (
-                mov.cloud[:: self.config.use_subsampled_corepoints]
-                if hasattr(mov, "cloud")
-                else mov
-            )
-        else:
-            logging.info(
-                "Nutze ref als Corepoints und nutze Subsamling: %s",
-                self.config.use_subsampled_corepoints,
-            )
-            corepoints = (
-                ref.cloud[:: self.config.use_subsampled_corepoints]
-                if hasattr(ref, "cloud")
-                else ref
-            )
+        mov, ref = self._load_epochs()
+        corepoints = self._derive_corepoints(mov, ref)
 
         if not isinstance(corepoints, np.ndarray):
             raise TypeError("Unerwarteter Typ für corepoints; erwarte np.ndarray (Nx3).")
 
         return mov, ref, corepoints
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _load_epochs(self) -> Tuple[object, object]:
+        """Detect input types and read epochs using :mod:`py4dgeo`."""
+
+        m_kind, m_path = self._detect(self.mov_base)
+        r_kind, r_path = self._detect(self.ref_base)
+
+        if m_kind == r_kind == "xyz":
+            logging.info("Nutze py4dgeo.read_from_xyz")
+            return py4dgeo.read_from_xyz(str(m_path), str(r_path))
+
+        if m_kind == r_kind == "laslike":
+            logging.info("Nutze py4dgeo.read_from_las (unterstützt .las und .laz)")
+            return py4dgeo.read_from_las(str(m_path), str(r_path))
+
+        if m_kind == r_kind == "ply" and hasattr(py4dgeo, "read_from_ply"):
+            logging.info("Nutze py4dgeo.read_from_ply")
+            return read_ply(str(m_path), str(r_path))
+
+        m_xyz = self._ensure_xyz(self.mov_base, (m_kind, m_path))
+        r_xyz = self._ensure_xyz(self.ref_base, (r_kind, r_path))
+        logging.info("Mischtypen → konvertiert zu XYZ → py4dgeo.read_from_xyz")
+        return py4dgeo.read_from_xyz(str(m_xyz), str(r_xyz))
+
+    def _derive_corepoints(self, mov: object, ref: object) -> np.ndarray:
+        """Derive core points from configured epoch with optional subsampling."""
+
+        use_mov = self.config.mov_as_corepoints
+        label = "mov" if use_mov else "ref"
+        logging.info(
+            "Nutze %s als Corepoints und nutze Subsamling: %s",
+            label,
+            self.config.use_subsampled_corepoints,
+        )
+
+        source = mov if use_mov else ref
+        data = source.cloud if hasattr(source, "cloud") else source
+        return data[:: self.config.use_subsampled_corepoints]
 
 
 __all__ = ["DataSource"]

--- a/tests/test_io/test_datasource.py
+++ b/tests/test_io/test_datasource.py
@@ -9,6 +9,7 @@ import numpy as np
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import m3c2.io.datasource as ds_module
+from m3c2.config.datasource_config import DataSourceConfig
 
 
 class DummyEpoch:
@@ -31,7 +32,8 @@ def test_detect_xyz(tmp_path: Path) -> None:
     folder.mkdir()
     (folder / "mov.xyz").write_text("0 0 0\n")
 
-    ds = ds_module.DataSource(str(folder))
+    cfg = DataSourceConfig(str(folder))
+    ds = ds_module.DataSource(cfg)
     kind, path = ds._detect(ds.mov_base)
 
     assert kind == "xyz"
@@ -41,7 +43,8 @@ def test_detect_xyz(tmp_path: Path) -> None:
 def test_ensure_xyz_from_gpc(tmp_path: Path) -> None:
     gpc_path = tmp_path / "mov.gpc"
     gpc_path.write_text("1 2 3\n4 5 6\n")
-    ds = ds_module.DataSource(str(tmp_path))
+    cfg = DataSourceConfig(str(tmp_path))
+    ds = ds_module.DataSource(cfg)
 
     xyz_path = ds._ensure_xyz(ds.mov_base, ("gpc", gpc_path))
 
@@ -58,7 +61,8 @@ def test_load_points_xyz(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(ds_module, "py4dgeo", DummyPy4DGeo)
 
-    ds = ds_module.DataSource(str(tmp_path))
+    cfg = DataSourceConfig(str(tmp_path))
+    ds = ds_module.DataSource(cfg)
     mov_epoch, ref_epoch, corepoints = ds.load_points()
 
     assert np.allclose(mov_epoch.cloud, mov)


### PR DESCRIPTION
## Summary
- simplify DataSource.load_points with helper methods
- add path helper properties and improve config usage
- adjust tests for new configuration-based API

## Testing
- `PYTHONPATH=$PWD pytest tests/test_io/test_datasource.py -q`
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'orchestration')*

------
https://chatgpt.com/codex/tasks/task_e_68b591ac71a083238acf4e72fb10c4a9