### PR TITLE
Refactor scale strategy handling

### DIFF
--- a/m3c2/cli/cli.py
+++ b/m3c2/cli/cli.py
@@ -71,6 +71,13 @@ class CLIApp:
             help="Sample size used for parameter estimation (normal & projection scale).",
         )
         parser.add_argument(
+            "--scale_strategy",
+            type=str,
+            choices=["radius"],
+            default="radius",
+            help="Strategy for scanning normal/projection scales.",
+        )
+        parser.add_argument(
             "--only_stats",
             action="store_true",
             help="Only compute statistics based on existing distance files (no M3C2 processing).",
@@ -228,15 +235,15 @@ class CLIApp:
         # Building pipeline configuration
 
         configs = self.create_pipeline_configurations(folder_ids, arg)
-        
-        # Running orchestrator
 
-        orchestrator = BatchOrchestrator(configs)
+        # Running orchestrator
+        orchestrator = BatchOrchestrator(configs, strategy=arg.scale_strategy)
 
         try:
             orchestrator.run_all()
         except Exception as e:
             self.logger.error("Error occurred while running orchestrator: %s", e)
             return 1
-        
+
         self.logger.info("Processing completed successfully.")
+        return 0

--- a/m3c2/core/param_estimator.py
+++ b/m3c2/core/param_estimator.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from typing import List, Tuple
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
-from m3c2.pipeline.strategies import ScaleScan
+from m3c2.pipeline.strategies import ScaleScan, ScanStrategy
 
 
 @dataclass
@@ -36,7 +36,7 @@ class ParamEstimator:
         neighbourhood in a regular grid.
     """
 
-    strategy: object
+    strategy: ScanStrategy
     k_neighbors: int = 6
 
     def estimate_min_spacing(self, points: np.ndarray) -> float:

--- a/m3c2/pipeline/strategies.py
+++ b/m3c2/pipeline/strategies.py
@@ -3,9 +3,25 @@
 from __future__ import annotations
 import logging
 from dataclasses import dataclass
-from typing import List, Optional, Protocol, Dict
+from typing import Dict, List, Optional, Protocol
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
+
+
+class ScanStrategy(Protocol):
+    """Protocol for scale scanning strategies used by :class:`ParamEstimator`."""
+
+    def scan(self, points: np.ndarray, min_spacing: float) -> List["ScaleScan"]:
+        """Scan a point cloud for candidate scales.
+
+        Parameters
+        ----------
+        points : ndarray
+            Point cloud coordinates.
+        min_spacing : float
+            Estimated minimal spacing between points.
+        """
+        ...
 
 
 @dataclass
@@ -260,3 +276,11 @@ class RadiusScanStrategy:
                     "nan" if np.isnan(res["relative_roughness"]) else f"{res['relative_roughness']:.4f}",
                 )
         return scans
+
+
+# Registry of available strategies for easier selection by name.  Additional
+# strategies can simply be added to this dictionary.
+STRATEGIES: Dict[str, type[ScanStrategy]] = {
+    "radius": RadiusScanStrategy,
+}
+

--- a/orchestration/__init__.py
+++ b/orchestration/__init__.py
@@ -1,0 +1,1 @@
+"""Backward compatible orchestration package."""

--- a/orchestration/m3c2_runner.py
+++ b/orchestration/m3c2_runner.py
@@ -1,0 +1,5 @@
+"""Compatibility wrapper exposing :class:`M3C2Runner` from the new package."""
+
+from m3c2.core.m3c2_runner import M3C2Runner
+
+__all__ = ["M3C2Runner"]


### PR DESCRIPTION
## Summary
- Allow choosing scale scan strategies via a registry and CLI flag
- Instantiate ParamEstimator with selected strategy per configuration
- Provide compatibility wrapper for legacy `orchestration.m3c2_runner`

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5abddde608323ac2d5e91be56bd06