### PR TITLE
Refactor pipeline orchestration into modular components

### DIFF
--- a/m3c2/pipeline/batch_orchestrator.py
+++ b/m3c2/pipeline/batch_orchestrator.py
@@ -8,17 +8,13 @@ estimation, execution of the core algorithm and subsequent analysis steps.
 import logging
 import os
 import time
-from typing import List, Tuple
+from typing import List
+
 import numpy as np
-from m3c2.io.datasource import DataSource
+
 from m3c2.config.pipeline_config import PipelineConfig
-from m3c2.core.param_estimator import ParamEstimator
 from m3c2.core.statistics import StatisticsService
-from m3c2.core.exclude_outliers import exclude_outliers
-from m3c2.visualization.visualization_service import VisualizationService
-from m3c2.core.m3c2_runner import M3C2Runner
-from m3c2.pipeline.strategies import ScaleScan, STRATEGIES
-from m3c2.config.datasource_config import DataSourceConfig
+from m3c2.pipeline.component_factory import PipelineComponentFactory
 
 logger = logging.getLogger(__name__)
 
@@ -37,25 +33,18 @@ class BatchOrchestrator:
     """
 
     def __init__(self, configs: List[PipelineConfig], strategy: str = "radius") -> None:
-        """Create a new orchestrator instance.
-
-        Parameters
-        ----------
-        configs : list[PipelineConfig]
-            Configurations describing each job to run.
-        strategy : str, optional
-            Name of the scale-scanning strategy to use.  Currently only
-            ``"radius"`` is implemented but the parameter allows an easy
-            extension in the future.
-        """
+        """Create a new orchestrator instance."""
 
         self.configs = configs
-        self.strategy_name = strategy
-        # The output format is identical for all configs; take it from the
-        # first configuration for convenience.
-        self.output_format = configs[0].output_format if configs else "excel"
+        output_format = configs[0].output_format if configs else "excel"
+        self.factory = PipelineComponentFactory(strategy, output_format)
+        self.data_loader = self.factory.create_data_loader()
+        self.scale_estimator = self.factory.create_scale_estimator()
+        self.m3c2_executor = self.factory.create_m3c2_executor()
+        self.outlier_handler = self.factory.create_outlier_handler()
+        self.statistics_runner = self.factory.create_statistics_runner()
+        self.visualization_runner = self.factory.create_visualization_runner()
 
-        # Log basic information about the incoming batch
         logger.info("=== BatchOrchestrator initialisiert ===")
         logger.info("Konfigurationen: %d Jobs", len(self.configs))
 
@@ -126,19 +115,15 @@ class BatchOrchestrator:
         )
         start = time.perf_counter()
 
-        # Load input data and determine core points
-        ds, mov, ref, corepoints = self._load_data(cfg)
+        ds, mov, ref, corepoints = self.data_loader._load_data(cfg)
+        tag = self._run_tag(cfg)
 
         if cfg.process_python_CC == "python" and not cfg.only_stats:
-            # Run M3C2 only when full processing (beyond statistics) is requested
             out_base = ds.config.folder
-            tag = self._run_tag(cfg)
             normal = projection = np.nan
             if cfg.use_existing_params:
-                # Reuse previously estimated parameters if available
                 params_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_params.txt")
                 normal, projection = StatisticsService._load_params(params_path)
-
                 if not np.isnan(normal) and not np.isnan(projection):
                     logger.info(
                         "[Params] geladen: %s (NormalScale=%.6f, SearchScale=%.6f)",
@@ -147,131 +132,34 @@ class BatchOrchestrator:
                         projection,
                     )
                 else:
-                    logger.info(
-                        "[Params] keine vorhandenen Parameter gefunden, berechne neu",
-                    )
+                    logger.info("[Params] keine vorhandenen Parameter gefunden, berechne neu")
             if np.isnan(normal) or np.isnan(projection):
-                # Estimate optimal scales and persist them for later runs
-                normal, projection = self._determine_scales(cfg, corepoints)
+                normal, projection = self.scale_estimator._determine_scales(cfg, corepoints)
                 self._save_params(cfg, normal, projection, out_base)
-            distances, _ = self._run_m3c2(
-                cfg, mov, ref, corepoints, normal, projection, out_base
+            distances, _ = self.m3c2_executor._run_m3c2(
+                cfg, mov, ref, corepoints, normal, projection, out_base, tag
             )
-
-            # Visualise distances including those flagged as outliers
-            self._generate_visuals(cfg, mov, distances, out_base)
+            self.visualization_runner._generate_visuals(cfg, mov, distances, out_base, tag)
 
         try:
-            # Generate distance files excluding outliers for further analysis
             logger.info("[Outlier] Entferne Ausreißer für %s", cfg.folder_id)
-            self._exclude_outliers(cfg, ds.config.folder)
+            self.outlier_handler._exclude_outliers(cfg, ds.config.folder, tag)
         except Exception:
             logger.exception("Fehler beim Entfernen von Ausreißern")
 
         try:
-            # Create coloured point clouds showing outliers and inliers
             logger.info("[Outlier] Erzeuge .ply Dateien für Outliers / Inliers …")
-            self._generate_clouds_outliers(cfg, ds.config.folder)
+            self.visualization_runner._generate_clouds_outliers(cfg, ds.config.folder, tag)
         except Exception:
             logger.exception("Fehler beim Erzeugen von .ply Dateien für Ausreißer / Inlier")
 
         try:
-            # Compute summary statistics for the processed dataset
-            self._compute_statistics(cfg, ref)
+            logger.info("[Statistics] Berechne Statistiken …")
+            self.statistics_runner._compute_statistics(cfg, ref, tag)
         except Exception:
             logger.exception("Fehler bei der Berechnung der Statistik")
 
         logger.info("[Job] %s abgeschlossen in %.3fs", cfg.folder_id, time.perf_counter() - start)
-
-    def _load_data(self, cfg: PipelineConfig) -> Tuple[DataSource, object, object, object]:
-        """Load point cloud data and core points according to the configuration.
-
-        Parameters
-        ----------
-        cfg : PipelineConfig
-            Configuration specifying file names and loading options.
-
-        Returns
-        -------
-        tuple
-            ``(DataSource, moving, reference, corepoints)`` where ``moving`` and
-            ``reference`` are objects understood by downstream services.
-        """
-        t0 = time.perf_counter()
-        # Create a data source that knows how to load the required clouds
-        
-        ds_config = DataSourceConfig(
-            os.path.join(cfg.data_dir, cfg.folder_id),
-            cfg.filename_mov,
-            cfg.filename_ref,
-            cfg.mov_as_corepoints,
-            cfg.use_subsampled_corepoints,
-        )
-        ds = DataSource(ds_config)
-        mov, ref, corepoints = ds.load_points()
-
-        logger.info(
-            "[Load] data/%s: mov=%s, ref=%s, corepoints=%s | %.3fs",
-            cfg.folder_id,
-            getattr(mov, "cloud", np.array([])).shape if hasattr(mov, "cloud") else "Epoch",
-            getattr(ref, "cloud", np.array([])).shape if hasattr(ref, "cloud") else "Epoch",
-            np.asarray(corepoints).shape,
-            time.perf_counter() - t0,
-        )
-        return ds, mov, ref, corepoints
-
-    def _determine_scales(self, cfg: PipelineConfig, corepoints) -> Tuple[float, float]:
-        """Determine suitable normal and projection scales.
-
-        Parameters
-        ----------
-        cfg : PipelineConfig
-            Configuration possibly providing override values.
-        corepoints : array-like
-            Points used for scale estimation.
-
-        Returns
-        -------
-        tuple of float
-            Chosen normal and projection scales.
-        """
-        if cfg.normal_override is not None and cfg.proj_override is not None:
-            # Respect user-specified override parameters
-            normal, projection = cfg.normal_override, cfg.proj_override
-            logger.info("[Scales] Overrides verwendet: normal=%.6f, proj=%.6f", normal, projection)
-            return normal, projection
-
-        t0 = time.perf_counter()
-        # Instantiate the desired scanning strategy for the current
-        # configuration.  ``STRATEGIES`` maps a user-facing name to the
-        # corresponding class.  This design keeps the orchestrator agnostic of
-        # concrete strategy implementations.
-        try:
-            strategy_cls = STRATEGIES[self.strategy_name]
-        except KeyError as exc:
-            raise ValueError(f"Unbekannte Strategie: {self.strategy_name}") from exc
-
-        strategy = strategy_cls(sample_size=cfg.sample_size)
-        estimator = ParamEstimator(strategy=strategy)
-
-        avg = estimator.estimate_min_spacing(corepoints)
-        logger.info("[Spacing] avg_spacing=%.6f (k=6) | %.3fs", avg, time.perf_counter() - t0)
-
-        t0 = time.perf_counter()
-        scans: List[ScaleScan] = estimator.scan_scales(corepoints, avg)
-        logger.info("[Scan] %d Skalen evaluiert | %.3fs", len(scans), time.perf_counter() - t0)
-
-        if scans:
-            # Log a few of the most promising scales for debugging
-            top_valid = sorted(scans, key=lambda s: s.valid_normals, reverse=True)[:5]
-            logger.debug("  Top(valid_normals): %s", [(round(s.scale, 6), int(s.valid_normals)) for s in top_valid])
-            top_smooth = sorted(scans, key=lambda s: (np.nan_to_num(s.roughness, nan=np.inf)))[:5]
-            logger.debug("  Top(min_roughness): %s", [(round(s.scale, 6), float(s.roughness)) for s in top_smooth])
-
-        t0 = time.perf_counter()
-        normal, projection = ParamEstimator.select_scales(scans)
-        logger.info("[Select] normal=%.6f, proj=%.6f | %.3fs", normal, projection, time.perf_counter() - t0)
-        return normal, projection
 
     def _save_params(self, cfg: PipelineConfig, normal: float, projection: float, out_base: str) -> None:
         """Persist determined scale parameters to disk.
@@ -293,206 +181,3 @@ class BatchOrchestrator:
         with open(params_path, "w") as f:
             f.write(f"NormalScale={normal}\nSearchScale={projection}\n")
         logger.info("[Params] gespeichert: %s", params_path)
-
-
-    def _run_m3c2(self, cfg: PipelineConfig, mov, ref, corepoints, normal: float, projection: float, out_base: str,
-    ) -> Tuple[np.ndarray, np.ndarray]:
-        """Run the M3C2 algorithm and persist results to disk.
-
-        Parameters
-        ----------
-        cfg : PipelineConfig
-            Current job configuration.
-        mov, ref : object
-            Moving and reference point clouds or epochs.
-        corepoints : array-like
-            Core points at which distances are evaluated.
-        normal : float
-            Normal scale to use in the computation.
-        projection : float
-            Projection scale to use in the computation.
-        out_base : str
-            Directory where result files are written.
-
-        Returns
-        -------
-        tuple of ndarray
-            Arrays of distances and their associated uncertainties.
-        """
-
-        tag = self._run_tag(cfg)
-
-        t0 = time.perf_counter()
-        runner = M3C2Runner()
-        distances, uncertainties = runner.run(mov, ref, corepoints, normal, projection)
-        duration = time.perf_counter() - t0
-        n = len(distances)
-        nan_share = float(np.isnan(distances).sum()) / n if n else 0.0
-        logger.info("[Run] Punkte=%d | NaN=%.2f%% | Zeit=%.3fs", n, 100.0 * nan_share, duration)
-
-        dists_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_distances.txt")
-        np.savetxt(dists_path, distances, fmt="%.6f")
-        logger.info("[Run] Distanzen gespeichert: %s (%d Werte, %.2f%% NaN)", dists_path, n, 100.0 * nan_share)
-
-        # Store XYZ coordinates alongside the computed distances
-        coords_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_distances_coordinates.txt")
-
-        # Handle both Epoch objects (with .cloud) and raw numpy arrays
-        if hasattr(mov, "cloud"):
-            xyz = np.asarray(mov.cloud)
-        else:
-            xyz = np.asarray(mov)
-        if xyz.shape[0] == distances.shape[0]:
-            arr = np.column_stack((xyz, distances))
-            header = "x y z distance"
-            np.savetxt(coords_path, arr, fmt="%.6f", header=header)
-            logger.info(f"[Run] Distanzen mit Koordinaten gespeichert: {coords_path}")
-        else:
-            logger.warning(f"[Run] Anzahl Koordinaten stimmt nicht mit Distanzen überein: {xyz.shape[0]} vs {distances.shape[0]}")
-
-        uncert_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_uncertainties.txt")
-        np.savetxt(uncert_path, uncertainties, fmt="%.6f")
-        logger.info("[Run] Unsicherheiten gespeichert: %s", uncert_path)
-
-        return distances, uncertainties
-
-    def _exclude_outliers(self, cfg: PipelineConfig, out_base: str) -> None:
-        """Remove statistical outliers from the distance results.
-
-        Parameters
-        ----------
-        cfg : PipelineConfig
-            Configuration containing outlier detection settings.
-        out_base : str
-            Directory where distance files are stored.
-        """
-        tag = self._run_tag(cfg)
-        exclude_outliers(
-            data_folder=out_base,
-            ref_variant=tag,
-            method=cfg.outlier_detection_method,
-            outlier_multiplicator=cfg.outlier_multiplicator
-        )
-
-
-    def _compute_statistics(self, cfg: PipelineConfig, ref) -> None:
-        """Compute and export statistical summaries for the run.
-
-        Parameters
-        ----------
-        cfg : PipelineConfig
-            Configuration describing which statistics to compute.
-        ref : object
-            Reference cloud used for statistics depending on mode.
-        """
-        tag = self._run_tag(cfg)
-        if cfg.stats_singleordistance == "distance":
-            logger.info(f"[Stats on Distance] Berechne M3C2-Statistiken {cfg.folder_id},{cfg.filename_ref} …")
-
-            if self.output_format == "excel":
-                out_path = os.path.join(f"outputs/{cfg.project}_output/{cfg.project}_m3c2_stats_distances.xlsx")
-            elif self.output_format == "json":
-                out_path = os.path.join(f"outputs/{cfg.project}_output/{cfg.project}_m3c2_stats_distances.json")
-            else:
-                raise ValueError("Ungültiges Ausgabeformat. Verwenden Sie 'excel' oder 'json'.")
-
-            StatisticsService.compute_m3c2_statistics(
-                folder_ids=[cfg.folder_id],
-                filename_ref=tag,
-                process_python_CC=cfg.process_python_CC,
-                out_path=out_path,
-                sheet_name="Results",
-                output_format=self.output_format,
-                outlier_multiplicator=cfg.outlier_multiplicator,
-                outlier_method=cfg.outlier_detection_method
-            )
-
-        if cfg.stats_singleordistance == "single":
-            logger.info(
-                f"[Stats on SingleClouds] Berechne M3C2-Statistiken {cfg.folder_id},{cfg.filename_ref} …",
-            )
-
-            if self.output_format == "excel":
-                out_path = os.path.join(f"outputs/{cfg.project}_output/{cfg.project}_m3c2_stats_clouds.xlsx")
-            elif self.output_format == "json":
-                out_path = os.path.join(f"outputs/{cfg.project}_output/{cfg.project}_m3c2_stats_clouds.json")
-            else:
-                raise ValueError("Ungültiges Ausgabeformat. Verwenden Sie 'excel' oder 'json'.")
-
-            StatisticsService.calc_single_cloud_stats(
-                folder_ids=[cfg.folder_id],
-                filename_mov=cfg.filename_mov,
-                filename_ref=cfg.filename_ref,
-                out_path=out_path,
-                sheet_name="CloudStats",
-                output_format=self.output_format
-            )
-
-    def _generate_visuals(self, cfg: PipelineConfig, mov, distances: np.ndarray, out_base: str) -> None:
-        """Create graphical and point cloud representations of results.
-
-        Parameters
-        ----------
-        cfg : PipelineConfig
-            Configuration for file naming.
-        mov : object
-            Moving point cloud containing coordinates.
-        distances : ndarray
-            Array of M3C2 distances corresponding to the moving cloud.
-        out_base : str
-            Directory to place the generated files in.
-        """
-        logger.info("[Visual] Erzeuge Visualisierungen …")
-        tag = self._run_tag(cfg)
-        os.makedirs(out_base, exist_ok=True)
-
-        hist_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_histogram.png")
-        ply_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_includenonvalid.ply")
-        ply_valid_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}.ply")
-
-        VisualizationService.histogram(distances, path=hist_path)
-        logger.info("[Visual] Histogram gespeichert: %s", hist_path)
-
-        colors = VisualizationService.colorize(mov.cloud, distances, outply=ply_path)
-        logger.info("[Visual] Farb-PLY gespeichert: %s", ply_path)
-
-        try:
-            VisualizationService.export_valid(mov.cloud, colors, distances, outply=ply_valid_path)
-            logger.info("[Visual] Valid-PLY gespeichert: %s", ply_valid_path)
-        except Exception as exc:
-            logger.warning("[Visual] Export valid-only übersprungen: %s", exc)
-
-    def _generate_clouds_outliers(self, cfg: PipelineConfig, out_base: str) -> None:
-        """Create coloured point clouds for inliers and outliers.
-
-        Parameters
-        ----------
-        cfg : PipelineConfig
-            Configuration providing file naming and outlier settings.
-        out_base : str
-            Directory where output files are written.
-        """
-        logger.info("[Visual] Erzeuge .ply Dateien für Outliers / Inliers …")
-        os.makedirs(out_base, exist_ok=True)
-        tag = self._run_tag(cfg)
-
-        ply_valid_path_outlier = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_outlier_{cfg.outlier_detection_method}.ply")
-        ply_valid_path_inlier = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_inlier_{cfg.outlier_detection_method}.ply")
-        txt_path_outlier = os.path.join(out_base, f"python_{tag}_m3c2_distances_coordinates_outlier_{cfg.outlier_detection_method}.txt")
-        txt_path_inlier = os.path.join(out_base, f"python_{tag}_m3c2_distances_coordinates_inlier_{cfg.outlier_detection_method}.txt")
-
-        try:
-            VisualizationService.txt_to_ply_with_distance_color(
-                txt_path=txt_path_outlier,
-                outply=ply_valid_path_outlier
-            )
-        except Exception as exc:
-            logger.warning("[Visual] Export valid-only übersprungen: %s", exc)
-
-        try:
-            VisualizationService.txt_to_ply_with_distance_color(
-                txt_path=txt_path_inlier,
-                outply=ply_valid_path_inlier
-            )
-        except Exception as exc:
-            logger.warning("[Visual] Export valid-only übersprungen: %s", exc)

--- a/m3c2/pipeline/component_factory.py
+++ b/m3c2/pipeline/component_factory.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+"""Factory for creating pipeline components used by :class:`BatchOrchestrator`."""
+
+from m3c2.pipeline.data_loader import DataLoader
+from m3c2.pipeline.scale_estimator import ScaleEstimator
+from m3c2.pipeline.m3c2_executor import M3C2Executor
+from m3c2.pipeline.outlier_handler import OutlierHandler
+from m3c2.pipeline.statistics_runner import StatisticsRunner
+from m3c2.pipeline.visualization_runner import VisualizationRunner
+
+
+class PipelineComponentFactory:
+    """Create configured instances of pipeline helper classes."""
+
+    def __init__(self, strategy_name: str, output_format: str) -> None:
+        self.strategy_name = strategy_name
+        self.output_format = output_format
+
+    def create_data_loader(self) -> DataLoader:
+        return DataLoader()
+
+    def create_scale_estimator(self) -> ScaleEstimator:
+        return ScaleEstimator(strategy_name=self.strategy_name)
+
+    def create_m3c2_executor(self) -> M3C2Executor:
+        return M3C2Executor()
+
+    def create_outlier_handler(self) -> OutlierHandler:
+        return OutlierHandler()
+
+    def create_statistics_runner(self) -> StatisticsRunner:
+        return StatisticsRunner(self.output_format)
+
+    def create_visualization_runner(self) -> VisualizationRunner:
+        return VisualizationRunner()

--- a/m3c2/pipeline/data_loader.py
+++ b/m3c2/pipeline/data_loader.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+"""Utility class for loading input data for the M3C2 pipeline."""
+
+import logging
+import os
+import time
+from typing import Tuple
+
+import numpy as np
+
+from m3c2.config.datasource_config import DataSourceConfig
+from m3c2.io.datasource import DataSource
+
+logger = logging.getLogger(__name__)
+
+
+class DataLoader:
+    """Load point cloud data and core points according to a configuration."""
+
+    def _load_data(self, cfg) -> Tuple[DataSource, object, object, object]:
+        """Load point clouds and core points as specified by ``cfg``."""
+        t0 = time.perf_counter()
+        ds_config = DataSourceConfig(
+            os.path.join(cfg.data_dir, cfg.folder_id),
+            cfg.filename_mov,
+            cfg.filename_ref,
+            cfg.mov_as_corepoints,
+            cfg.use_subsampled_corepoints,
+        )
+        ds = DataSource(ds_config)
+        mov, ref, corepoints = ds.load_points()
+        logger.info(
+            "[Load] data/%s: mov=%s, ref=%s, corepoints=%s | %.3fs",
+            cfg.folder_id,
+            getattr(mov, "cloud", np.array([])).shape if hasattr(mov, "cloud") else "Epoch",
+            getattr(ref, "cloud", np.array([])).shape if hasattr(ref, "cloud") else "Epoch",
+            np.asarray(corepoints).shape,
+            time.perf_counter() - t0,
+        )
+        return ds, mov, ref, corepoints

--- a/m3c2/pipeline/m3c2_executor.py
+++ b/m3c2/pipeline/m3c2_executor.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+"""Execute the M3C2 algorithm and persist results."""
+
+import logging
+import os
+import time
+from typing import Tuple
+
+import numpy as np
+
+from m3c2.core.m3c2_runner import M3C2Runner
+
+logger = logging.getLogger(__name__)
+
+
+class M3C2Executor:
+    """Run the M3C2 algorithm for a given configuration."""
+
+    def _run_m3c2(self, cfg, mov, ref, corepoints, normal: float, projection: float, out_base: str, tag: str,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Run M3C2 and store distances and uncertainties."""
+        t0 = time.perf_counter()
+        runner = M3C2Runner()
+        distances, uncertainties = runner.run(mov, ref, corepoints, normal, projection)
+        duration = time.perf_counter() - t0
+        n = len(distances)
+        nan_share = float(np.isnan(distances).sum()) / n if n else 0.0
+        logger.info("[Run] Punkte=%d | NaN=%.2f%% | Zeit=%.3fs", n, 100.0 * nan_share, duration)
+
+        dists_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_distances.txt")
+        np.savetxt(dists_path, distances, fmt="%.6f")
+        logger.info("[Run] Distanzen gespeichert: %s (%d Werte, %.2f%% NaN)", dists_path, n, 100.0 * nan_share)
+
+        coords_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_distances_coordinates.txt")
+        if hasattr(mov, "cloud"):
+            xyz = np.asarray(mov.cloud)
+        else:
+            xyz = np.asarray(mov)
+        if xyz.shape[0] == distances.shape[0]:
+            arr = np.column_stack((xyz, distances))
+            header = "x y z distance"
+            np.savetxt(coords_path, arr, fmt="%.6f", header=header)
+            logger.info(f"[Run] Distanzen mit Koordinaten gespeichert: {coords_path}")
+        else:
+            logger.warning(
+                f"[Run] Anzahl Koordinaten stimmt nicht mit Distanzen überein: {xyz.shape[0]} vs {distances.shape[0]}"
+            )
+
+        uncert_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_m3c2_uncertainties.txt")
+        np.savetxt(uncert_path, uncertainties, fmt="%.6f")
+        logger.info("[Run] Unsicherheiten gespeichert: %s", uncert_path)
+
+        return distances, uncertainties

--- a/m3c2/pipeline/outlier_handler.py
+++ b/m3c2/pipeline/outlier_handler.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+"""Handle exclusion of statistical outliers."""
+
+import logging
+
+from m3c2.core.exclude_outliers import exclude_outliers
+
+logger = logging.getLogger(__name__)
+
+
+class OutlierHandler:
+    """Remove statistical outliers from M3C2 results."""
+
+    def _exclude_outliers(self, cfg, out_base: str, tag: str) -> None:
+        """Remove outliers based on configuration settings."""
+        exclude_outliers(
+            data_folder=out_base,
+            ref_variant=tag,
+            method=cfg.outlier_detection_method,
+            outlier_multiplicator=cfg.outlier_multiplicator,
+        )

--- a/m3c2/pipeline/scale_estimator.py
+++ b/m3c2/pipeline/scale_estimator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+"""Determine optimal scales for the M3C2 algorithm."""
+
+import logging
+import time
+from typing import List, Tuple
+
+import numpy as np
+
+from m3c2.core.param_estimator import ParamEstimator
+from m3c2.pipeline.strategies import ScaleScan, STRATEGIES
+
+logger = logging.getLogger(__name__)
+
+
+class ScaleEstimator:
+    """Estimate normal and projection scales using a scanning strategy."""
+
+    def __init__(self, strategy_name: str = "radius") -> None:
+        self.strategy_name = strategy_name
+
+    def _determine_scales(self, cfg, corepoints) -> Tuple[float, float]:
+        """Determine suitable normal and projection scales."""
+        if cfg.normal_override is not None and cfg.proj_override is not None:
+            normal, projection = cfg.normal_override, cfg.proj_override
+            logger.info("[Scales] Overrides verwendet: normal=%.6f, proj=%.6f", normal, projection)
+            return normal, projection
+
+        t0 = time.perf_counter()
+        try:
+            strategy_cls = STRATEGIES[self.strategy_name]
+        except KeyError as exc:
+            raise ValueError(f"Unbekannte Strategie: {self.strategy_name}") from exc
+
+        strategy = strategy_cls(sample_size=cfg.sample_size)
+        estimator = ParamEstimator(strategy=strategy)
+
+        avg = estimator.estimate_min_spacing(corepoints)
+        logger.info("[Spacing] avg_spacing=%.6f (k=6) | %.3fs", avg, time.perf_counter() - t0)
+
+        t0 = time.perf_counter()
+        scans: List[ScaleScan] = estimator.scan_scales(corepoints, avg)
+        logger.info("[Scan] %d Skalen evaluiert | %.3fs", len(scans), time.perf_counter() - t0)
+
+        if scans:
+            top_valid = sorted(scans, key=lambda s: s.valid_normals, reverse=True)[:5]
+            logger.debug("  Top(valid_normals): %s", [(round(s.scale, 6), int(s.valid_normals)) for s in top_valid])
+            top_smooth = sorted(scans, key=lambda s: (np.nan_to_num(s.roughness, nan=np.inf)))[:5]
+            logger.debug("  Top(min_roughness): %s", [(round(s.scale, 6), float(s.roughness)) for s in top_smooth])
+
+        t0 = time.perf_counter()
+        normal, projection = ParamEstimator.select_scales(scans)
+        logger.info("[Select] normal=%.6f, proj=%.6f | %.3fs", normal, projection, time.perf_counter() - t0)
+        return normal, projection

--- a/m3c2/pipeline/statistics_runner.py
+++ b/m3c2/pipeline/statistics_runner.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+"""Compute and export statistical summaries for the M3C2 pipeline."""
+
+import logging
+import os
+
+from m3c2.core.statistics import StatisticsService
+
+logger = logging.getLogger(__name__)
+
+
+class StatisticsRunner:
+    """Run various statistical evaluations depending on configuration."""
+
+    def __init__(self, output_format: str) -> None:
+        self.output_format = output_format
+
+    def _compute_statistics(self, cfg, ref, tag: str) -> None:
+        """Compute M3C2 statistics for a job."""
+        if cfg.stats_singleordistance == "distance":
+            logger.info(
+                f"[Stats on Distance] Berechne M3C2-Statistiken {cfg.folder_id},{cfg.filename_ref} …"
+            )
+            if self.output_format == "excel":
+                out_path = os.path.join(
+                    f"outputs/{cfg.project}_output/{cfg.project}_m3c2_stats_distances.xlsx"
+                )
+            elif self.output_format == "json":
+                out_path = os.path.join(
+                    f"outputs/{cfg.project}_output/{cfg.project}_m3c2_stats_distances.json"
+                )
+            else:
+                raise ValueError("Ungültiges Ausgabeformat. Verwenden Sie 'excel' oder 'json'.")
+
+            StatisticsService.compute_m3c2_statistics(
+                folder_ids=[cfg.folder_id],
+                filename_ref=tag,
+                process_python_CC=cfg.process_python_CC,
+                out_path=out_path,
+                sheet_name="Results",
+                output_format=self.output_format,
+                outlier_multiplicator=cfg.outlier_multiplicator,
+                outlier_method=cfg.outlier_detection_method,
+            )
+
+        if cfg.stats_singleordistance == "single":
+            logger.info(
+                f"[Stats on SingleClouds] Berechne M3C2-Statistiken {cfg.folder_id},{cfg.filename_ref} …",
+            )
+            if self.output_format == "excel":
+                out_path = os.path.join(
+                    f"outputs/{cfg.project}_output/{cfg.project}_m3c2_stats_clouds.xlsx"
+                )
+            elif self.output_format == "json":
+                out_path = os.path.join(
+                    f"outputs/{cfg.project}_output/{cfg.project}_m3c2_stats_clouds.json"
+                )
+            else:
+                raise ValueError("Ungültiges Ausgabeformat. Verwenden Sie 'excel' oder 'json'.")
+
+            StatisticsService.calc_single_cloud_stats(
+                folder_ids=[cfg.folder_id],
+                filename_mov=cfg.filename_mov,
+                filename_ref=cfg.filename_ref,
+                out_path=out_path,
+                sheet_name="CloudStats",
+                output_format=self.output_format,
+            )

--- a/m3c2/pipeline/visualization_runner.py
+++ b/m3c2/pipeline/visualization_runner.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+"""Generate visual representations of M3C2 results."""
+
+import logging
+import os
+
+import numpy as np
+
+from m3c2.visualization.visualization_service import VisualizationService
+
+logger = logging.getLogger(__name__)
+
+
+class VisualizationRunner:
+    """Create histograms and coloured point clouds for M3C2 outputs."""
+
+    def _generate_visuals(self, cfg, mov, distances: np.ndarray, out_base: str, tag: str) -> None:
+        """Create visualisations for computed distances."""
+        logger.info("[Visual] Erzeuge Visualisierungen …")
+        os.makedirs(out_base, exist_ok=True)
+        hist_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_histogram.png")
+        ply_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_includenonvalid.ply")
+        ply_valid_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}.ply")
+
+        VisualizationService.histogram(distances, path=hist_path)
+        logger.info("[Visual] Histogram gespeichert: %s", hist_path)
+
+        colors = VisualizationService.colorize(mov.cloud, distances, outply=ply_path)
+        logger.info("[Visual] Farb-PLY gespeichert: %s", ply_path)
+
+        try:
+            VisualizationService.export_valid(mov.cloud, colors, distances, outply=ply_valid_path)
+            logger.info("[Visual] Valid-PLY gespeichert: %s", ply_valid_path)
+        except Exception as exc:
+            logger.warning("[Visual] Export valid-only übersprungen: %s", exc)
+
+    def _generate_clouds_outliers(self, cfg, out_base: str, tag: str) -> None:
+        """Create coloured point clouds for inliers and outliers."""
+        logger.info("[Visual] Erzeuge .ply Dateien für Outliers / Inliers …")
+        os.makedirs(out_base, exist_ok=True)
+        ply_valid_path_outlier = os.path.join(
+            out_base, f"{cfg.process_python_CC}_{tag}_outlier_{cfg.outlier_detection_method}.ply"
+        )
+        ply_valid_path_inlier = os.path.join(
+            out_base, f"{cfg.process_python_CC}_{tag}_inlier_{cfg.outlier_detection_method}.ply"
+        )
+        txt_path_outlier = os.path.join(
+            out_base, f"python_{tag}_m3c2_distances_coordinates_outlier_{cfg.outlier_detection_method}.txt"
+        )
+        txt_path_inlier = os.path.join(
+            out_base, f"python_{tag}_m3c2_distances_coordinates_inlier_{cfg.outlier_detection_method}.txt"
+        )
+
+        try:
+            VisualizationService.txt_to_ply_with_distance_color(
+                txt_path=txt_path_outlier, outply=ply_valid_path_outlier
+            )
+        except Exception as exc:
+            logger.warning("[Visual] Export valid-only übersprungen: %s", exc)
+
+        try:
+            VisualizationService.txt_to_ply_with_distance_color(
+                txt_path=txt_path_inlier, outply=ply_valid_path_inlier
+            )
+        except Exception as exc:
+            logger.warning("[Visual] Export valid-only übersprungen: %s", exc)

--- a/tests/test_pipeline/test_batch_orchestrator.py
+++ b/tests/test_pipeline/test_batch_orchestrator.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import os
 import numpy as np
-from m3c2.pipeline.batch_orchestrator import BatchOrchestrator
 from m3c2.config.pipeline_config import PipelineConfig
+from m3c2.pipeline.data_loader import DataLoader
 
 
 class DummyDS:
@@ -30,10 +30,10 @@ def test_load_data_uses_data_dir(tmp_path, monkeypatch):
     )
 
     monkeypatch.setattr(
-        "m3c2.pipeline.batch_orchestrator.DataSource", DummyDS
+        "m3c2.pipeline.data_loader.DataSource", DummyDS
     )
-    orch = BatchOrchestrator([cfg])
-    ds, mov, ref, corepoints = orch._load_data(cfg)
+    loader = DataLoader()
+    ds, mov, ref, corepoints = loader._load_data(cfg)
 
     assert ds.config.folder == os.path.join(cfg.data_dir, cfg.folder_id)
     assert mov.shape == (1, 3)


### PR DESCRIPTION
## Summary
- Add dedicated pipeline helper classes for data loading, scale estimation, M3C2 execution, outlier handling, statistics and visualization
- Introduce `PipelineComponentFactory` and refactor `BatchOrchestrator` to delegate work to these components
- Adjust tests for new `DataLoader` API

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5ce3ccbec83238fecb53e1465c7e0