### PR TITLE
Add CLIApp tests for parser defaults and orchestrator invocation

### DIFF
--- a/tests/test_cli/test_cli_app.py
+++ b/tests/test_cli/test_cli_app.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from m3c2.cli.cli import CLIApp
+
+
+def test_build_parser_defaults() -> None:
+    parser = CLIApp().build_parser()
+    args = parser.parse_args([])
+    assert args.data_dir == "data"
+    assert args.scale_strategy == "radius"
+
+
+def test_run_invokes_orchestrator(monkeypatch, tmp_path) -> None:
+    # create folder structure expected by CLIApp.run
+    folder = tmp_path / "001"
+    folder.mkdir()
+
+    orchestrator_cls = MagicMock()
+    monkeypatch.setattr("m3c2.cli.cli.BatchOrchestrator", orchestrator_cls)
+
+    app = CLIApp()
+    result = app.run(["--data_dir", str(tmp_path), "--folders", "001"])
+
+    assert result == 0
+    orchestrator_cls.assert_called_once()
+
+    configs_arg, kwargs = orchestrator_cls.call_args
+    configs = configs_arg[0]
+    assert kwargs["strategy"] == "radius"
+    assert len(configs) == 1
+    cfg = configs[0]
+    assert cfg.data_dir == str(tmp_path)
+    assert cfg.folder_id == "001"
+
+    orchestrator_instance = orchestrator_cls.return_value
+    orchestrator_instance.run_all.assert_called_once_with()


### PR DESCRIPTION
## Summary
- add CLIApp parser tests for default `--data_dir` and `--scale_strategy`
- verify `CLIApp.run` calls `BatchOrchestrator` with parsed configuration

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5da4218f88323beda4f52d931879b