### PR TITLE
Add PipelineConfig default and immutability tests

### DIFF
--- a/tests/test_config/test_pipeline_config.py
+++ b/tests/test_config/test_pipeline_config.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pytest
+from dataclasses import FrozenInstanceError
+
+# Ensure package root is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from m3c2.config.pipeline_config import PipelineConfig
+
+
+def test_defaults_and_immutability():
+    config = PipelineConfig(
+        data_dir="data",
+        folder_id="folder",
+        filename_mov="mov.las",
+        filename_ref="ref.las",
+        mov_as_corepoints=True,
+        use_subsampled_corepoints=0,
+        only_stats=False,
+        stats_singleordistance="single",
+        sample_size=10,
+        project="demo",
+    )
+
+    # Default attributes
+    assert config.normal_override is None
+    assert config.proj_override is None
+    assert config.use_existing_params is False
+    assert config.outlier_multiplicator == 3.0
+    assert config.outlier_detection_method == "rmse"
+    assert config.process_python_CC == "python"
+    assert config.output_format == "excel"
+    assert config.log_level == "INFO"
+
+    # Fields are frozen
+    with pytest.raises(FrozenInstanceError):
+        config.project = "other"


### PR DESCRIPTION
## Summary
- add tests instantiating `PipelineConfig` with minimal arguments
- verify default values like outlier multiplier, output format, and log level
- ensure dataclass fields are frozen

## Testing
- `pytest tests/test_config/test_pipeline_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5da46d994832380d949bf6020f0f6