### PR TITLE
Add unit test for argparse GUI start button

### DIFF
--- a/tests/test_gui/test_argparse_gui.py
+++ b/tests/test_gui/test_argparse_gui.py
@@ -1,0 +1,86 @@
+"""Tests for the :mod:`m3c2.gui.argparse_gui` module."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from unittest import mock
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+# ``argparse_gui`` depends on ``m3c2.cli.main_generatecloud`` for its example
+# usage.  Provide a stub module so the import succeeds.
+stub_main = types.SimpleNamespace(
+    convert_one=mock.MagicMock(),
+    convert_all=mock.MagicMock(),
+    logger=mock.MagicMock(),
+)
+sys.modules["m3c2.cli.main_generatecloud"] = stub_main
+
+from m3c2.gui.argparse_gui import run_gui
+
+
+def test_run_gui_invokes_parse_args_and_main_func() -> None:
+    parser = argparse.ArgumentParser(prog="prog")
+    parser.add_argument("--flag", action="store_true")
+    parser.add_argument("--opt")
+    parser.add_argument("pos")
+
+    button_cmds: dict[str, mock.Mock] = {}
+    vars_created: list[object] = []
+
+    class FakeStringVar:
+        def __init__(self, value: object | None = None) -> None:
+            self.value = value
+            vars_created.append(self)
+
+        def get(self) -> object:
+            return self.value
+
+        def set(self, value: object) -> None:
+            self.value = value
+
+    class FakeBooleanVar(FakeStringVar):
+        pass
+    def fake_widget(*args, **kwargs):
+        widget = mock.MagicMock()
+        widget.grid = mock.MagicMock()
+        return widget
+
+    def fake_button(root, text: str, command):
+        btn = mock.MagicMock()
+        btn.grid = mock.MagicMock()
+        button_cmds[text] = command
+        return btn
+
+    fake_tk = types.SimpleNamespace(
+        Tk=lambda: mock.MagicMock(mainloop=lambda: None, destroy=lambda: None, title=lambda *args, **kwargs: None),
+        Label=fake_widget,
+        Entry=fake_widget,
+        Checkbutton=fake_widget,
+        OptionMenu=fake_widget,
+        Button=fake_button,
+        StringVar=FakeStringVar,
+        BooleanVar=FakeBooleanVar,
+    )
+
+    parse_mock = mock.MagicMock(return_value=mock.sentinel.args)
+    parser.parse_args = parse_mock
+    main_mock = mock.MagicMock()
+
+    with mock.patch("m3c2.gui.argparse_gui.tk", fake_tk), mock.patch(
+        "m3c2.gui.argparse_gui.messagebox"
+    ):
+        run_gui(parser, main_mock)
+
+        flag_var, opt_var, pos_var = vars_created
+        flag_var.set(True)
+        opt_var.set("value")
+        pos_var.set("positional")
+
+        button_cmds["Start"]()
+
+    parse_mock.assert_called_once_with(["--flag", "--opt", "value", "positional"])
+    main_mock.assert_called_once_with(mock.sentinel.args)


### PR DESCRIPTION
## Summary
- add GUI test for run_gui ensuring Start button assembles argv and triggers parse_args

## Testing
- `pre-commit run --files tests/test_gui/__init__.py tests/test_gui/test_argparse_gui.py` *(fails: command not found)*
- `pytest tests/test_gui/test_argparse_gui.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5da4b124483238b6f4f66830cf5a5