### PR TITLE
Add format handler and logging utils tests

### DIFF
--- a/tests/test_io/test_format_handler.py
+++ b/tests/test_io/test_format_handler.py
@@ -1,0 +1,66 @@
+"""Tests for the :mod:`m3c2.io.format_handler` module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+import m3c2.io.format_handler as fh
+
+
+def test_read_xyz(tmp_path: Path) -> None:
+    data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    path = tmp_path / "points.xyz"
+    np.savetxt(path, data, fmt="%.1f")
+
+    arr = fh.read_xyz(path)
+
+    assert np.allclose(arr, data)
+
+
+def test_read_ply(tmp_path: Path) -> None:
+    path = tmp_path / "points.ply"
+    path.write_text(
+        """ply
+format ascii 1.0
+element vertex 2
+property float x
+property float y
+property float z
+end_header
+1 2 3
+4 5 6
+"""
+    )
+
+    arr = fh.read_ply(path)
+    expected = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+    assert np.allclose(arr, expected)
+
+
+def test_read_obj(tmp_path: Path) -> None:
+    path = tmp_path / "mesh.obj"
+    path.write_text("""v 1 2 3\nv 4 5 6\n""")
+
+    arr = fh.read_obj(path)
+    expected = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+    assert np.allclose(arr, expected)
+
+
+def test_read_las_missing_dependency(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "dummy.las"
+    path.write_text("dummy")
+
+    def fake_import(name: str) -> None:
+        raise ImportError
+
+    monkeypatch.setattr(fh, "import_module", fake_import)
+
+    with pytest.raises(RuntimeError):
+        fh.read_las(path)

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,32 @@
+"""Tests for :mod:`m3c2.io.logging_utils`."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from m3c2.io.logging_utils import setup_logging
+
+
+def test_setup_logging_idempotent(tmp_path: Path) -> None:
+    logger = logging.getLogger()
+    # ensure clean logger state
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+
+    log_file = tmp_path / "test.log"
+
+    setup_logging(log_file=str(log_file))
+    handlers_before = list(logger.handlers)
+
+    setup_logging(log_file=str(log_file))
+    handlers_after = list(logger.handlers)
+
+    assert handlers_after == handlers_before
+    assert len(logger.handlers) == 2
+
+    # cleanup
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)


### PR DESCRIPTION
## Summary
- Add tests for format handlers to ensure XYZ, PLY, OBJ parsing and proper error on missing `laspy`
- Add logging utility test verifying `setup_logging` idempotency without duplicate handlers

## Testing
- `pytest tests/test_io/test_format_handler.py tests/test_logging_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5da4f2fd08323afb81e47239540ff