### PR TITLE
Add visualization plotter tests

### DIFF
--- a/tests/test_visualization/test_bland_altman_plotter.py
+++ b/tests/test_visualization/test_bland_altman_plotter.py
@@ -1,0 +1,34 @@
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+
+from m3c2.visualization import bland_altman_plotter
+from m3c2.visualization.bland_altman_plotter import bland_altman_plot
+
+
+def test_bland_altman_plot_creates_file(tmp_path, monkeypatch):
+    def fake_load(fid, refs):
+        return np.array([1.0, 2.0, 3.0]), np.array([1.1, 2.1, 3.1])
+
+    monkeypatch.setattr(bland_altman_plotter, "_load_and_mask", fake_load)
+    bland_altman_plot(["fid"], ["r1", "r2"], outdir=str(tmp_path))
+    expected = tmp_path / "bland_altman_fid_r1_vs_r2.png"
+    assert expected.is_file()
+
+
+def test_bland_altman_plot_handles_none(tmp_path, monkeypatch):
+    def fake_load(fid, refs):
+        return None
+
+    monkeypatch.setattr(bland_altman_plotter, "_load_and_mask", fake_load)
+    bland_altman_plot(["fid"], ["r1", "r2"], outdir=str(tmp_path))
+    assert not (tmp_path / "bland_altman_fid_r1_vs_r2.png").exists()
+
+
+def test_bland_altman_plot_handles_empty_arrays(tmp_path, monkeypatch):
+    def fake_load(fid, refs):
+        return np.array([]), np.array([])
+
+    monkeypatch.setattr(bland_altman_plotter, "_load_and_mask", fake_load)
+    bland_altman_plot(["fid"], ["r1", "r2"], outdir=str(tmp_path))
+    assert not (tmp_path / "bland_altman_fid_r1_vs_r2.png").exists()

--- a/tests/test_visualization/test_overlay_plotter.py
+++ b/tests/test_visualization/test_overlay_plotter.py
@@ -1,0 +1,55 @@
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+
+from m3c2.visualization.overlay_plotter import (
+    get_common_range,
+    plot_overlay_histogram,
+    plot_overlay_gauss,
+    plot_overlay_weibull,
+    plot_overlay_boxplot,
+    plot_overlay_qq,
+)
+
+
+def test_get_common_range_empty():
+    data_min, data_max, x = get_common_range({})
+    assert data_min == 0.0
+    assert data_max == 1.0
+    assert len(x) == 500
+
+
+def test_plot_functions_create_files(tmp_path):
+    data = {
+        "A": np.array([0.0, 1.0, 2.0]),
+        "B": np.array([1.0, 2.0, 3.0]),
+    }
+    colors = {"A": "#ff0000", "B": "#00ff00"}
+    data_min, data_max, x = get_common_range(data)
+    gauss_params = {k: (float(np.mean(v)), float(np.std(v))) for k, v in data.items()}
+
+    plot_overlay_histogram("f", "name", data, 10, data_min, data_max, colors, str(tmp_path))
+    assert (tmp_path / "f_name_OverlayHistogramm.png").is_file()
+
+    plot_overlay_gauss("f", "name", data, gauss_params, x, colors, str(tmp_path))
+    assert (tmp_path / "f_name_OverlayGaussFits.png").is_file()
+
+    plot_overlay_weibull("f", "name", data, x, colors, str(tmp_path))
+    assert (tmp_path / "f_name_OverlayWeibullFits.png").is_file()
+
+    plot_overlay_boxplot("f", "name", data, colors, str(tmp_path))
+    assert (tmp_path / "f_name_Boxplot.png").is_file()
+
+    plot_overlay_qq("f", "name", data, colors, str(tmp_path))
+    assert (tmp_path / "f_name_QQPlot.png").is_file()
+
+
+def test_plot_overlay_boxplot_empty(tmp_path):
+    # Should not raise and produce no file when data is empty
+    plot_overlay_boxplot("f", "name", {}, {}, str(tmp_path))
+    assert not (tmp_path / "f_name_Boxplot.png").exists()
+
+    # Histogram should still create an empty file
+    data_min, data_max, _ = get_common_range({})
+    plot_overlay_histogram("f", "name", {}, 10, data_min, data_max, {}, str(tmp_path))
+    assert (tmp_path / "f_name_OverlayHistogramm.png").is_file()

--- a/tests/test_visualization/test_plot_service_compare_distances.py
+++ b/tests/test_visualization/test_plot_service_compare_distances.py
@@ -30,3 +30,21 @@ def test_overlay_plots_delegates(monkeypatch, tmp_path):
     assert len(lr.calls) == 1
     assert ba.calls[0][0] == ("f1",)
     assert lr.calls[0][0] == ("f1",)
+
+def test_overlay_plots_no_options(monkeypatch, tmp_path):
+    ba = CallRecorder()
+    pb = CallRecorder()
+    lr = CallRecorder()
+
+    monkeypatch.setattr(plot_comparedistances_service, "bland_altman_plot", ba)
+    monkeypatch.setattr(plot_comparedistances_service, "passing_bablok_plot", pb)
+    monkeypatch.setattr(plot_comparedistances_service, "linear_regression_plot", lr)
+
+    cfg = PlotConfig(folder_ids=["f1"], filenames=["ref", "ref_ai"], bins=10, outdir=str(tmp_path), project="P")
+    opts = PlotOptionsComparedistances(plot_blandaltman=False, plot_passingbablok=False, plot_linearregression=False)
+
+    PlotServiceCompareDistances.overlay_plots(cfg, opts)
+
+    assert ba.calls == []
+    assert pb.calls == []
+    assert lr.calls == []


### PR DESCRIPTION
## Summary
- add tests for overlay plotter ensuring plot files and empty-data handling
- cover bland-altman plotter including mocked error paths
- expand distance comparison plot service tests for disabled options

## Testing
- `python -m pytest tests/test_visualization -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5da54c8e083239c35b5e09c334a0c