### PR TITLE
Add main entry point test and defer CLIApp import

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,23 +5,23 @@ Run Pipeline using the command line:
     Option 1. With arguments in config.json file: python -m main
     Option 2. Directly with arguments in the command line:
 
-                python -m main 
-                --data_dir ./data  
-                --folders 0342-0349  
-                --filename_ref ref.ply  
-                --filename_mov mov.ply  
-                --project MARS 
-                --output_format excel 
-                --outlier_detection_method rmse 
+                python -m main
+                --data_dir ./data
+                --folders 0342-0349
+                --filename_ref ref.ply
+                --filename_mov mov.ply
+                --project MARS
+                --output_format excel
+                --outlier_detection_method rmse
                 --outlier_multiplicator 3.0
                 --log_level INFO
 """
 
-from m3c2.cli.cli import CLIApp
-
 
 def main() -> None:
     """Execute the command line application."""
+    from m3c2.cli.cli import CLIApp
+
     CLIApp().run()
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,13 @@
+from importlib import reload
+from unittest.mock import patch
+
+
+def test_main_invokes_cliapp_run_once():
+    """Ensure that main.main runs CLIApp.run exactly once and is import-safe."""
+    with patch("m3c2.cli.cli.CLIApp.run") as mock_run:
+        import main  # Import after patching to ensure no side effects
+        main = reload(main)
+
+        mock_run.assert_not_called()
+        main.main()
+        mock_run.assert_called_once()


### PR DESCRIPTION
## Summary
- Move CLIApp import inside `main.main` for safer importing
- Add unit test ensuring `main.main` invokes `CLIApp.run` once and is import-safe

## Testing
- `python -m pytest tests/test_main.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5da57da188323b5871e8f22448b34