### PR TITLE
Add tests for Excel header comment helpers

### DIFF
--- a/m3c2/io/excel_writer/comments_stats_clouds.py
+++ b/m3c2/io/excel_writer/comments_stats_clouds.py
@@ -147,5 +147,6 @@ def add_cloud_header_comments(xlsx_path: str,
 
     wb.save(xlsx_path)
 
-# Beispielaufruf:
-add_cloud_header_comments("cloud_stats.xlsx", sheet_name="CloudStats")
+if __name__ == "__main__":
+    # Beispielaufruf:
+    add_cloud_header_comments("cloud_stats.xlsx", sheet_name="CloudStats")

--- a/tests/test_io/excel_writer/__init__.py
+++ b/tests/test_io/excel_writer/__init__.py
@@ -1,0 +1,1 @@
+# Placeholder for package

--- a/tests/test_io/excel_writer/test_comments.py
+++ b/tests/test_io/excel_writer/test_comments.py
@@ -1,0 +1,74 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from openpyxl import Workbook
+
+from m3c2.io.excel_writer.comments_stats_clouds import (
+    add_cloud_header_comments,
+    CLOUD_HEADER_COMMENTS,
+)
+from m3c2.io.excel_writer.comments_stats_distances import (
+    add_header_comments,
+    HEADER_COMMENTS,
+)
+
+
+def test_add_cloud_header_comments_sets_comments():
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "CloudStats"
+    ws.append(["Timestamp", "Other"])
+
+    with patch(
+        "m3c2.io.excel_writer.comments_stats_clouds.load_workbook",
+        return_value=wb,
+    ):
+        with patch.object(wb, "save", MagicMock()):
+            add_cloud_header_comments("dummy.xlsx", sheet_name="CloudStats")
+
+    assert ws["A1"].comment is not None
+    assert ws["A1"].comment.text == CLOUD_HEADER_COMMENTS["Timestamp"]
+    assert ws["B1"].comment is None
+
+
+def test_add_cloud_header_comments_missing_sheet():
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Other"
+
+    with patch(
+        "m3c2.io.excel_writer.comments_stats_clouds.load_workbook",
+        return_value=wb,
+    ):
+        with pytest.raises(ValueError):
+            add_cloud_header_comments("dummy.xlsx", sheet_name="CloudStats")
+
+
+def test_add_header_comments_sets_comments():
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Results"
+    ws.append(["Timestamp", "Other"])
+
+    with patch(
+        "m3c2.io.excel_writer.comments_stats_distances.load_workbook",
+        return_value=wb,
+    ):
+        with patch.object(wb, "save", MagicMock()):
+            add_header_comments("dummy.xlsx", sheet_name="Results")
+
+    assert ws["A1"].comment is not None
+    assert ws["A1"].comment.text == HEADER_COMMENTS["Timestamp"]
+    assert ws["B1"].comment is None
+
+
+def test_add_header_comments_missing_sheet():
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Other"
+
+    with patch(
+        "m3c2.io.excel_writer.comments_stats_distances.load_workbook",
+        return_value=wb,
+    ):
+        with pytest.raises(ValueError):
+            add_header_comments("dummy.xlsx", sheet_name="Results")


### PR DESCRIPTION
## Summary
- wrap example call in `comments_stats_clouds` with a `__main__` guard
- add tests for Excel header comment helpers using mocked workbooks

## Testing
- `PYTHONPATH=. pytest tests/test_io/excel_writer/test_comments.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0a7be9c83239874477373eed148