### PR TITLE
Add statistics module test coverage

### DIFF
--- a/tests/test_core/test_basic_metrics.py
+++ b/tests/test_core/test_basic_metrics.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from m3c2.core.statistics.basic_metrics import basic_stats, fit_distributions
+
+
+def test_basic_stats_empty_array():
+    res = basic_stats(np.array([]), tolerance=0.1)
+    assert res["Valid Count"] == 0
+    assert np.isnan(res["Mean"])
+    assert np.isnan(res["Jaccard Index"])
+
+
+def test_basic_stats_computation():
+    arr = np.array([1.0, 2.0, 3.0])
+    res = basic_stats(arr, tolerance=2.0)
+    assert res["Valid Count"] == 3
+    assert res["Min"] == 1.0
+    assert res["Max"] == 3.0
+    assert np.isclose(res["Mean"], 2.0)
+    assert np.isclose(res["Median"], 2.0)
+    assert np.isclose(res["Std Empirical"], np.std(arr))
+    assert np.isclose(res["Within-Tolerance"], 2.0 / 3.0)
+    assert np.isclose(res["Jaccard Index"], 1.0 / 3.0)
+
+
+def test_fit_distributions_basic():
+    rng = np.random.default_rng(0)
+    data = rng.normal(loc=1.0, scale=2.0, size=500)
+    hist, bin_edges = np.histogram(data, bins=20)
+    res = fit_distributions(data, hist, bin_edges, None)
+    assert np.isclose(res["mu"], np.mean(data), atol=0.1)
+    assert np.isclose(res["std"], np.std(data), atol=0.1)
+    assert res["pearson_gauss"] >= 0
+    assert res["pearson_weib"] >= 0
+
+
+def test_fit_distributions_length_mismatch():
+    with pytest.raises(AssertionError):
+        fit_distributions(np.arange(10), np.ones(5), np.arange(6), None)

--- a/tests/test_core/test_cloud_quality.py
+++ b/tests/test_core/test_cloud_quality.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from sklearn.neighbors import NearestNeighbors
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from m3c2.core.statistics.cloud_quality import _calc_single_cloud_stats
+
+
+def test_calc_single_cloud_stats_empty():
+    with pytest.raises(ValueError):
+        _calc_single_cloud_stats(np.array([]))
+
+
+def test_calc_single_cloud_stats_wrong_shape():
+    with pytest.raises(ValueError):
+        _calc_single_cloud_stats(np.zeros((3, 2)))
+
+
+def test_calc_single_cloud_stats_basic():
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 2.0],
+            [1.0, 1.0, 3.0],
+        ]
+    )
+    # compute expected NN distances for comparison
+    k = 2
+    nn = NearestNeighbors(n_neighbors=min(k + 1, len(points))).fit(points)
+    dists, _ = nn.kneighbors(points)
+    expected_all = float(np.mean(dists[:, 1:]))
+    expected_kth = float(np.mean(dists[:, min(k, dists.shape[1] - 1)]))
+
+    stats = _calc_single_cloud_stats(
+        points,
+        area_m2=1.0,
+        radius=2.0,
+        k=k,
+        sample_size=None,
+        use_convex_hull=False,
+    )
+
+    assert stats["Num Points"] == 4
+    assert stats["Area Source"] == "given"
+    assert stats["Density Global [pt/m^2]"] == pytest.approx(4.0)
+    assert stats["Z Min"] == 0.0
+    assert stats["Z Max"] == 3.0
+    assert stats["Z Mean"] == pytest.approx(1.5)
+    assert stats["Sampled Points"] == 4
+    assert stats["Mean NN Dist All"] == pytest.approx(expected_all)
+    assert stats["Mean NN Dist k-th"] == pytest.approx(expected_kth)

--- a/tests/test_core/test_exporters.py
+++ b/tests/test_core/test_exporters.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from m3c2.core.statistics import exporters
+
+
+def test_write_table_calls_excel_by_default():
+    rows = [{"a": 1}]
+    with patch("m3c2.core.statistics.exporters._append_df_to_excel") as m_excel:
+        exporters.write_table(rows, out_path="dummy.xlsx")
+        m_excel.assert_called_once()
+        df_arg = m_excel.call_args.args[0]
+        assert isinstance(df_arg, pd.DataFrame)
+        assert df_arg.iloc[0]["a"] == 1
+
+
+def test_write_table_calls_json_when_requested():
+    rows = [{"a": 1}]
+    with patch("m3c2.core.statistics.exporters._append_df_to_json") as m_json:
+        exporters.write_table(rows, out_path="dummy.json", output_format="json")
+        m_json.assert_called_once()
+
+
+def test_write_table_empty_rows():
+    with patch("m3c2.core.statistics.exporters._append_df_to_excel") as m_excel:
+        exporters.write_table([], out_path="dummy.xlsx")
+        m_excel.assert_not_called()
+
+
+def test_write_cloud_stats_excel():
+    rows = [{"a": 1}]
+    with patch("os.path.exists", return_value=False), \
+         patch("m3c2.core.statistics.exporters.pd.ExcelWriter") as m_writer, \
+         patch("pandas.DataFrame.to_excel") as m_to_excel:
+        m_writer.return_value.__enter__.return_value = MagicMock()
+        exporters.write_cloud_stats(rows, out_path="dummy.xlsx")
+        m_to_excel.assert_called_once()
+
+
+def test_write_cloud_stats_json():
+    rows = [{"a": 1}]
+    with patch("os.path.exists", return_value=False), \
+         patch("pandas.DataFrame.to_json") as m_to_json:
+        exporters.write_cloud_stats(rows, out_path="dummy.json", output_format="json")
+        m_to_json.assert_called_once()
+
+
+def test_write_cloud_stats_empty_rows():
+    with patch("pandas.DataFrame.to_excel") as m_to_excel:
+        exporters.write_cloud_stats([], out_path="dummy.xlsx")
+        m_to_excel.assert_not_called()

--- a/tests/test_core/test_outliers.py
+++ b/tests/test_core/test_outliers.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from m3c2.core.statistics.outliers import compute_outliers, get_outlier_mask
+
+
+def test_get_outlier_mask_rmse():
+    arr = np.array([0.0, 0.0, 10.0])
+    mask, threshold = get_outlier_mask(arr, method="rmse", outlier_multiplicator=1.0)
+    rmse = np.sqrt(np.mean(arr ** 2))
+    assert mask.tolist() == [False, False, True]
+    assert threshold == pytest.approx(rmse)
+
+
+def test_get_outlier_mask_iqr():
+    arr = np.array([1.0, 2.0, 3.0, 100.0])
+    mask, threshold = get_outlier_mask(arr, method="iqr", outlier_multiplicator=1.0)
+    assert mask.tolist() == [False, False, False, True]
+    assert isinstance(threshold, str)
+
+
+def test_get_outlier_mask_std():
+    arr = np.array([0.0, 0.0, 10.0])
+    mask, threshold = get_outlier_mask(arr, method="std", outlier_multiplicator=1.0)
+    mu = np.mean(arr)
+    std = np.std(arr)
+    expected = np.abs(arr - mu) > std
+    assert mask.tolist() == expected.tolist()
+    assert threshold == pytest.approx(std)
+
+
+def test_get_outlier_mask_nmad():
+    arr = np.array([0.0, 0.0, 0.0, 10.0])
+    mask, threshold = get_outlier_mask(arr, method="nmad", outlier_multiplicator=1.0)
+    assert mask.tolist() == [False, False, False, True]
+    assert threshold == pytest.approx(0.0)
+
+
+def test_get_outlier_mask_invalid_method():
+    with pytest.raises(ValueError):
+        get_outlier_mask(np.array([1.0]), method="foo", outlier_multiplicator=1.0)
+
+
+def test_compute_outliers_basic():
+    inliers = np.array([1.0, -2.0, 3.0])
+    outliers = np.array([10.0, -20.0])
+    res = compute_outliers(inliers, outliers)
+    assert res["outlier_count"] == 2
+    assert res["inlier_count"] == 3
+    assert res["pos_out"] == 1
+    assert res["neg_out"] == 1
+    assert res["mean_out"] == pytest.approx(np.mean(outliers))
+    assert res["std_out"] == pytest.approx(np.std(outliers))
+
+
+def test_compute_outliers_empty_outliers():
+    inliers = np.array([1.0, 2.0])
+    outliers = np.array([])
+    res = compute_outliers(inliers, outliers)
+    assert res["outlier_count"] == 0
+    assert np.isnan(res["mean_out"])
+    assert np.isnan(res["std_out"])


### PR DESCRIPTION
## Summary
- add basic metric tests covering empty arrays, metric calculations, and distribution fitting
- add cloud quality tests for invalid inputs and core statistics
- add exporter tests using mocks to avoid filesystem access
- add outlier detection tests for multiple methods and stats

## Testing
- `pytest tests/test_core -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0ab0fbc8323ac5a330729763f84