### PR TITLE
Expose pipeline helper methods as public API

### DIFF
--- a/m3c2/pipeline/batch_orchestrator.py
+++ b/m3c2/pipeline/batch_orchestrator.py
@@ -115,7 +115,7 @@ class BatchOrchestrator:
         )
         start = time.perf_counter()
 
-        ds, mov, ref, corepoints = self.data_loader._load_data(cfg)
+        ds, mov, ref, corepoints = self.data_loader.load_data(cfg)
         tag = self._run_tag(cfg)
 
         if cfg.process_python_CC == "python" and not cfg.only_stats:
@@ -134,28 +134,28 @@ class BatchOrchestrator:
                 else:
                     logger.info("[Params] keine vorhandenen Parameter gefunden, berechne neu")
             if np.isnan(normal) or np.isnan(projection):
-                normal, projection = self.scale_estimator._determine_scales(cfg, corepoints)
+                normal, projection = self.scale_estimator.determine_scales(cfg, corepoints)
                 self._save_params(cfg, normal, projection, out_base)
-            distances, _ = self.m3c2_executor._run_m3c2(
+            distances, _ = self.m3c2_executor.run_m3c2(
                 cfg, mov, ref, corepoints, normal, projection, out_base, tag
             )
-            self.visualization_runner._generate_visuals(cfg, mov, distances, out_base, tag)
+            self.visualization_runner.generate_visuals(cfg, mov, distances, out_base, tag)
 
         try:
             logger.info("[Outlier] Entferne Ausreißer für %s", cfg.folder_id)
-            self.outlier_handler._exclude_outliers(cfg, ds.config.folder, tag)
+            self.outlier_handler.exclude_outliers(cfg, ds.config.folder, tag)
         except Exception:
             logger.exception("Fehler beim Entfernen von Ausreißern")
 
         try:
             logger.info("[Outlier] Erzeuge .ply Dateien für Outliers / Inliers …")
-            self.visualization_runner._generate_clouds_outliers(cfg, ds.config.folder, tag)
+            self.visualization_runner.generate_clouds_outliers(cfg, ds.config.folder, tag)
         except Exception:
             logger.exception("Fehler beim Erzeugen von .ply Dateien für Ausreißer / Inlier")
 
         try:
             logger.info("[Statistics] Berechne Statistiken …")
-            self.statistics_runner._compute_statistics(cfg, ref, tag)
+            self.statistics_runner.compute_statistics(cfg, ref, tag)
         except Exception:
             logger.exception("Fehler bei der Berechnung der Statistik")
 

--- a/m3c2/pipeline/data_loader.py
+++ b/m3c2/pipeline/data_loader.py
@@ -17,8 +17,11 @@ logger = logging.getLogger(__name__)
 class DataLoader:
     """Load point cloud data and core points according to a configuration."""
 
-    def _load_data(self, cfg) -> Tuple[DataSource, object, object, object]:
-        """Load point clouds and core points as specified by ``cfg``."""
+    def load_data(self, cfg) -> Tuple[DataSource, object, object, object]:
+        """Load point clouds and core points as specified by ``cfg``.
+
+        This method is part of the public pipeline API.
+        """
         t0 = time.perf_counter()
         ds_config = DataSourceConfig(
             os.path.join(cfg.data_dir, cfg.folder_id),

--- a/m3c2/pipeline/m3c2_executor.py
+++ b/m3c2/pipeline/m3c2_executor.py
@@ -16,9 +16,12 @@ logger = logging.getLogger(__name__)
 class M3C2Executor:
     """Run the M3C2 algorithm for a given configuration."""
 
-    def _run_m3c2(self, cfg, mov, ref, corepoints, normal: float, projection: float, out_base: str, tag: str,
+    def run_m3c2(self, cfg, mov, ref, corepoints, normal: float, projection: float, out_base: str, tag: str,
     ) -> Tuple[np.ndarray, np.ndarray]:
-        """Run M3C2 and store distances and uncertainties."""
+        """Run M3C2 and store distances and uncertainties.
+
+        This method is part of the public pipeline API.
+        """
         t0 = time.perf_counter()
         runner = M3C2Runner()
         distances, uncertainties = runner.run(mov, ref, corepoints, normal, projection)

--- a/m3c2/pipeline/outlier_handler.py
+++ b/m3c2/pipeline/outlier_handler.py
@@ -11,8 +11,11 @@ logger = logging.getLogger(__name__)
 class OutlierHandler:
     """Remove statistical outliers from M3C2 results."""
 
-    def _exclude_outliers(self, cfg, out_base: str, tag: str) -> None:
-        """Remove outliers based on configuration settings."""
+    def exclude_outliers(self, cfg, out_base: str, tag: str) -> None:
+        """Remove outliers based on configuration settings.
+
+        This method is part of the public pipeline API.
+        """
         exclude_outliers(
             data_folder=out_base,
             ref_variant=tag,

--- a/m3c2/pipeline/scale_estimator.py
+++ b/m3c2/pipeline/scale_estimator.py
@@ -19,8 +19,11 @@ class ScaleEstimator:
     def __init__(self, strategy_name: str = "radius") -> None:
         self.strategy_name = strategy_name
 
-    def _determine_scales(self, cfg, corepoints) -> Tuple[float, float]:
-        """Determine suitable normal and projection scales."""
+    def determine_scales(self, cfg, corepoints) -> Tuple[float, float]:
+        """Determine suitable normal and projection scales.
+
+        This method is part of the public pipeline API.
+        """
         if cfg.normal_override is not None and cfg.proj_override is not None:
             normal, projection = cfg.normal_override, cfg.proj_override
             logger.info("[Scales] Overrides verwendet: normal=%.6f, proj=%.6f", normal, projection)

--- a/m3c2/pipeline/statistics_runner.py
+++ b/m3c2/pipeline/statistics_runner.py
@@ -15,8 +15,11 @@ class StatisticsRunner:
     def __init__(self, output_format: str) -> None:
         self.output_format = output_format
 
-    def _compute_statistics(self, cfg, ref, tag: str) -> None:
-        """Compute M3C2 statistics for a job."""
+    def compute_statistics(self, cfg, ref, tag: str) -> None:
+        """Compute M3C2 statistics for a job.
+
+        This method is part of the public pipeline API.
+        """
         if cfg.stats_singleordistance == "distance":
             logger.info(
                 f"[Stats on Distance] Berechne M3C2-Statistiken {cfg.folder_id},{cfg.filename_ref} …"

--- a/m3c2/pipeline/visualization_runner.py
+++ b/m3c2/pipeline/visualization_runner.py
@@ -14,8 +14,11 @@ logger = logging.getLogger(__name__)
 class VisualizationRunner:
     """Create histograms and coloured point clouds for M3C2 outputs."""
 
-    def _generate_visuals(self, cfg, mov, distances: np.ndarray, out_base: str, tag: str) -> None:
-        """Create visualisations for computed distances."""
+    def generate_visuals(self, cfg, mov, distances: np.ndarray, out_base: str, tag: str) -> None:
+        """Create visualisations for computed distances.
+
+        This method is part of the public pipeline API.
+        """
         logger.info("[Visual] Erzeuge Visualisierungen …")
         os.makedirs(out_base, exist_ok=True)
         hist_path = os.path.join(out_base, f"{cfg.process_python_CC}_{tag}_histogram.png")
@@ -34,8 +37,11 @@ class VisualizationRunner:
         except Exception as exc:
             logger.warning("[Visual] Export valid-only übersprungen: %s", exc)
 
-    def _generate_clouds_outliers(self, cfg, out_base: str, tag: str) -> None:
-        """Create coloured point clouds for inliers and outliers."""
+    def generate_clouds_outliers(self, cfg, out_base: str, tag: str) -> None:
+        """Create coloured point clouds for inliers and outliers.
+
+        This method is part of the public pipeline API.
+        """
         logger.info("[Visual] Erzeuge .ply Dateien für Outliers / Inliers …")
         os.makedirs(out_base, exist_ok=True)
         ply_valid_path_outlier = os.path.join(

--- a/tests/test_pipeline/test_batch_orchestrator.py
+++ b/tests/test_pipeline/test_batch_orchestrator.py
@@ -33,7 +33,7 @@ def test_load_data_uses_data_dir(tmp_path, monkeypatch):
         "m3c2.pipeline.data_loader.DataSource", DummyDS
     )
     loader = DataLoader()
-    ds, mov, ref, corepoints = loader._load_data(cfg)
+    ds, mov, ref, corepoints = loader.load_data(cfg)
 
     assert ds.config.folder == os.path.join(cfg.data_dir, cfg.folder_id)
     assert mov.shape == (1, 3)

--- a/tests/test_pipeline/test_m3c2_executor.py
+++ b/tests/test_pipeline/test_m3c2_executor.py
@@ -26,7 +26,7 @@ def test_run_m3c2_writes_outputs(tmp_path, monkeypatch, caplog):
     caplog.set_level(logging.INFO)
 
     executor = M3C2Executor()
-    d, u = executor._run_m3c2(
+    d, u = executor.run_m3c2(
         cfg,
         mov,
         ref,

--- a/tests/test_pipeline/test_outlier_handler.py
+++ b/tests/test_pipeline/test_outlier_handler.py
@@ -18,6 +18,6 @@ def test_exclude_outliers(monkeypatch):
     cfg = SimpleNamespace(outlier_detection_method="iqr", outlier_multiplicator=2.5)
     handler = OutlierHandler()
 
-    handler._exclude_outliers(cfg, out_base="base", tag="tag")
+    handler.exclude_outliers(cfg, out_base="base", tag="tag")
 
     assert called["args"] == ("base", "tag", "iqr", 2.5)

--- a/tests/test_pipeline/test_scale_estimator.py
+++ b/tests/test_pipeline/test_scale_estimator.py
@@ -66,7 +66,7 @@ def test_determine_scales_with_mock_strategy(monkeypatch):
     cfg = _minimal_cfg()
     estimator = ScaleEstimator(strategy_name="dummy")
 
-    normal, projection = estimator._determine_scales(cfg, np.zeros((1, 3)))
+    normal, projection = estimator.determine_scales(cfg, np.zeros((1, 3)))
 
     assert normal == 1.0
     assert projection == 2.0
@@ -78,7 +78,7 @@ def test_determine_scales_unknown_strategy(monkeypatch):
     estimator = ScaleEstimator(strategy_name="radius")
 
     with pytest.raises(ValueError):
-        estimator._determine_scales(cfg, np.zeros((1, 3)))
+        estimator.determine_scales(cfg, np.zeros((1, 3)))
 
 
 def test_radius_scan_strategy_evaluate_radius_scale_plane():

--- a/tests/test_pipeline/test_statistics_runner.py
+++ b/tests/test_pipeline/test_statistics_runner.py
@@ -31,7 +31,7 @@ def test_compute_statistics_distance(monkeypatch, caplog):
 
     runner = StatisticsRunner(output_format="excel")
     caplog.set_level(logging.INFO)
-    runner._compute_statistics(cfg, ref=None, tag="ref")
+    runner.compute_statistics(cfg, ref=None, tag="ref")
 
     assert called["out_path"].endswith("proj_m3c2_stats_distances.xlsx")
     assert any("Stats on Distance" in rec.message for rec in caplog.records)
@@ -59,7 +59,7 @@ def test_compute_statistics_single(monkeypatch, caplog):
 
     runner = StatisticsRunner(output_format="json")
     caplog.set_level(logging.INFO)
-    runner._compute_statistics(cfg, ref=None, tag="ref")
+    runner.compute_statistics(cfg, ref=None, tag="ref")
 
     assert called["out_path"].endswith("proj_m3c2_stats_clouds.json")
     assert any("Stats on SingleClouds" in rec.message for rec in caplog.records)
@@ -69,7 +69,7 @@ def test_invalid_output_format():
     runner = StatisticsRunner(output_format="xml")
     cfg = SimpleNamespace(stats_singleordistance="distance", folder_id="fid", filename_ref="ref")
     try:
-        runner._compute_statistics(cfg, ref=None, tag="ref")
+        runner.compute_statistics(cfg, ref=None, tag="ref")
     except ValueError:
         pass
     else:


### PR DESCRIPTION
## Summary
- promote pipeline helper methods like `load_data`, `determine_scales`, and `run_m3c2` to public API
- adjust `BatchOrchestrator` and tests to use new method names
- document that these methods form part of the public pipeline API

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e50b4ba0832396e32e9b36d97067