### PR TITLE
Handle missing cloud attribute in visualization

### DIFF
--- a/m3c2/pipeline/visualization_runner.py
+++ b/m3c2/pipeline/visualization_runner.py
@@ -24,12 +24,16 @@ class VisualizationRunner:
 
         VisualizationService.histogram(distances, path=hist_path)
         logger.info("[Visual] Histogram gespeichert: %s", hist_path)
+        cloud = getattr(mov, "cloud", None)
+        if cloud is None:
+            logger.warning("[Visual] mov besitzt kein 'cloud'-Attribut; Visualisierung übersprungen")
+            return
 
-        colors = VisualizationService.colorize(mov.cloud, distances, outply=ply_path)
+        colors = VisualizationService.colorize(cloud, distances, outply=ply_path)
         logger.info("[Visual] Farb-PLY gespeichert: %s", ply_path)
 
         try:
-            VisualizationService.export_valid(mov.cloud, colors, distances, outply=ply_valid_path)
+            VisualizationService.export_valid(cloud, colors, distances, outply=ply_valid_path)
             logger.info("[Visual] Valid-PLY gespeichert: %s", ply_valid_path)
         except Exception as exc:
             logger.warning("[Visual] Export valid-only übersprungen: %s", exc)

--- a/tests/visualization_runner_test.py
+++ b/tests/visualization_runner_test.py
@@ -1,0 +1,65 @@
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+
+from m3c2.pipeline.visualization_runner import VisualizationRunner
+from m3c2.visualization.visualization_service import VisualizationService
+
+
+def test_generate_visuals_with_cloud(monkeypatch, tmp_path):
+    runner = VisualizationRunner()
+    cfg = SimpleNamespace(process_python_CC="foo")
+    mov = SimpleNamespace(cloud="dummy")
+    distances = np.array([1.0, 2.0])
+
+    calls = {}
+
+    def fake_histogram(dist, path):
+        calls["histogram"] = (dist, path)
+
+    def fake_colorize(cloud, dist, outply):
+        calls["colorize"] = (cloud, dist, outply)
+        return "colors"
+
+    def fake_export_valid(cloud, colors, dist, outply):
+        calls["export_valid"] = (cloud, colors, dist, outply)
+
+    monkeypatch.setattr(VisualizationService, "histogram", fake_histogram)
+    monkeypatch.setattr(VisualizationService, "colorize", fake_colorize)
+    monkeypatch.setattr(VisualizationService, "export_valid", fake_export_valid)
+
+    runner._generate_visuals(cfg, mov, distances, str(tmp_path), "tag")
+
+    assert "colorize" in calls
+    assert "export_valid" in calls
+
+
+def test_generate_visuals_without_cloud(monkeypatch, tmp_path, caplog):
+    runner = VisualizationRunner()
+    cfg = SimpleNamespace(process_python_CC="foo")
+    mov = SimpleNamespace()  # no cloud attribute
+    distances = np.array([1.0, 2.0])
+
+    calls = {}
+
+    def fake_histogram(dist, path):
+        calls["histogram"] = (dist, path)
+
+    def fake_colorize(*args, **kwargs):
+        calls["colorize"] = True
+
+    def fake_export_valid(*args, **kwargs):
+        calls["export_valid"] = True
+
+    monkeypatch.setattr(VisualizationService, "histogram", fake_histogram)
+    monkeypatch.setattr(VisualizationService, "colorize", fake_colorize)
+    monkeypatch.setattr(VisualizationService, "export_valid", fake_export_valid)
+
+    with caplog.at_level(logging.WARNING):
+        runner._generate_visuals(cfg, mov, distances, str(tmp_path), "tag")
+
+    assert "histogram" in calls
+    assert "colorize" not in calls
+    assert "export_valid" not in calls
+    assert "kein 'cloud'-Attribut" in caplog.text


### PR DESCRIPTION
## Summary
- avoid AttributeError in VisualizationRunner when mov has no `cloud`
- log warning and skip color export if `cloud` missing
- add unit tests for VisualizationRunner with and without `cloud`

## Testing
- `python -m pytest tests/visualization_runner_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e513af44832396ea30429c2573d6