### PR TITLE
Handle empty scale scans

### DIFF
--- a/m3c2/pipeline/scale_estimator.py
+++ b/m3c2/pipeline/scale_estimator.py
@@ -44,9 +44,19 @@ class ScaleEstimator:
 
         if scans:
             top_valid = sorted(scans, key=lambda s: s.valid_normals, reverse=True)[:5]
-            logger.debug("  Top(valid_normals): %s", [(round(s.scale, 6), int(s.valid_normals)) for s in top_valid])
-            top_smooth = sorted(scans, key=lambda s: (np.nan_to_num(s.roughness, nan=np.inf)))[:5]
-            logger.debug("  Top(min_roughness): %s", [(round(s.scale, 6), float(s.roughness)) for s in top_smooth])
+            logger.debug(
+                "  Top(valid_normals): %s",  # noqa: G004
+                [(round(s.scale, 6), int(s.valid_normals)) for s in top_valid],
+            )
+            top_smooth = sorted(
+                scans, key=lambda s: (np.nan_to_num(s.roughness, nan=np.inf))
+            )[:5]
+            logger.debug(
+                "  Top(min_roughness): %s",  # noqa: G004
+                [(round(s.scale, 6), float(s.roughness)) for s in top_smooth],
+            )
+        else:
+            raise ValueError("Scan-Strategie lieferte keine Skalen.")
 
         t0 = time.perf_counter()
         normal, projection = ParamEstimator.select_scales(scans)

--- a/tests/test_pipeline/test_scale_estimator.py
+++ b/tests/test_pipeline/test_scale_estimator.py
@@ -42,6 +42,15 @@ class DummyEstimator:
         return 1.0, 2.0
 
 
+class DummyEstimatorNoScans(DummyEstimator):
+    def scan_scales(self, corepoints, avg_spacing):
+        return []
+
+    @staticmethod
+    def select_scales(scans):
+        raise AssertionError("select_scales should not be called")
+
+
 def _minimal_cfg(**kwargs) -> PipelineConfig:
     defaults = dict(
         data_dir="",
@@ -78,6 +87,17 @@ def test_determine_scales_unknown_strategy(monkeypatch):
     estimator = ScaleEstimator(strategy_name="radius")
 
     with pytest.raises(ValueError):
+        estimator._determine_scales(cfg, np.zeros((1, 3)))
+
+
+def test_determine_scales_empty_scan_results(monkeypatch):
+    monkeypatch.setitem(se_module.STRATEGIES, "dummy", DummyStrategy)
+    monkeypatch.setattr(se_module, "ParamEstimator", DummyEstimatorNoScans)
+
+    cfg = _minimal_cfg()
+    estimator = ScaleEstimator(strategy_name="dummy")
+
+    with pytest.raises(ValueError, match="keine Skalen"):
         estimator._determine_scales(cfg, np.zeros((1, 3)))
 
 


### PR DESCRIPTION
## Summary
- avoid calling `ParamEstimator.select_scales` when no scan results are available
- raise a clear error for empty scan results
- cover empty scan result with unit test

## Testing
- `PYTHONPATH=. python -m pytest tests/test_pipeline/test_scale_estimator.py -q`
- `PYTHONPATH=. python -m pytest tests/test_core/test_param_estimator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e51c19d88323952a2499a215efd8