### PR TITLE
Improve exception handling in batch orchestrator

### DIFF
--- a/m3c2/pipeline/batch_orchestrator.py
+++ b/m3c2/pipeline/batch_orchestrator.py
@@ -86,8 +86,19 @@ class BatchOrchestrator:
         for cfg in self.configs:
             try:
                 self._run_single(cfg)
+            except (IOError, ValueError):
+                logger.exception(
+                    "[Job] Fehler in Job '%s' (Version %s)",
+                    cfg.folder_id,
+                    cfg.filename_ref,
+                )
             except Exception:
-                logger.exception("[Job] Fehler in Job '%s' (Version %s)", cfg.folder_id, cfg.filename_ref)
+                logger.exception(
+                    "[Job] Unerwarteter Fehler in Job '%s' (Version %s)",
+                    cfg.folder_id,
+                    cfg.filename_ref,
+                )
+                raise
 
     def _run_single(self, cfg: PipelineConfig) -> None:
         """Execute the pipeline for a single configuration.
@@ -144,20 +155,29 @@ class BatchOrchestrator:
         try:
             logger.info("[Outlier] Entferne Ausreißer für %s", cfg.folder_id)
             self.outlier_handler.exclude_outliers(cfg, ds.config.folder, tag)
-        except Exception:
+        except (IOError, ValueError):
             logger.exception("Fehler beim Entfernen von Ausreißern")
+        except Exception:
+            logger.exception("Unerwarteter Fehler beim Entfernen von Ausreißern")
+            raise
 
         try:
             logger.info("[Outlier] Erzeuge .ply Dateien für Outliers / Inliers …")
             self.visualization_runner.generate_clouds_outliers(cfg, ds.config.folder, tag)
-        except Exception:
+        except (IOError, ValueError):
             logger.exception("Fehler beim Erzeugen von .ply Dateien für Ausreißer / Inlier")
+        except Exception:
+            logger.exception("Unerwarteter Fehler beim Erzeugen von .ply Dateien für Ausreißer / Inlier")
+            raise
 
         try:
             logger.info("[Statistics] Berechne Statistiken …")
             self.statistics_runner.compute_statistics(cfg, ref, tag)
-        except Exception:
+        except (IOError, ValueError):
             logger.exception("Fehler bei der Berechnung der Statistik")
+        except Exception:
+            logger.exception("Unerwarteter Fehler bei der Berechnung der Statistik")
+            raise
 
         logger.info("[Job] %s abgeschlossen in %.3fs", cfg.folder_id, time.perf_counter() - start)
 

--- a/tests/test_pipeline/test_batch_orchestrator_errors.py
+++ b/tests/test_pipeline/test_batch_orchestrator_errors.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from types import SimpleNamespace
+
+from m3c2.config.pipeline_config import PipelineConfig
+from m3c2.pipeline.batch_orchestrator import BatchOrchestrator
+
+
+def _cfg(tmp_path, folder_id="run"):
+    return PipelineConfig(
+        data_dir=str(tmp_path),
+        folder_id=folder_id,
+        filename_mov="mov.xyz",
+        filename_ref="ref.xyz",
+        mov_as_corepoints=True,
+        use_subsampled_corepoints=1,
+        only_stats=True,
+        stats_singleordistance="single",
+        sample_size=1,
+        project="proj",
+    )
+
+
+def test_run_all_continues_on_value_error(monkeypatch, tmp_path):
+    cfg1 = _cfg(tmp_path, "a")
+    cfg2 = _cfg(tmp_path, "b")
+    orchestrator = BatchOrchestrator([cfg1, cfg2])
+
+    calls = []
+
+    def side_effect(cfg):
+        calls.append(cfg.folder_id)
+        if cfg is cfg1:
+            raise ValueError("boom")
+
+    monkeypatch.setattr(orchestrator, "_run_single", side_effect)
+
+    orchestrator.run_all()
+
+    assert calls == ["a", "b"]
+
+
+def test_run_all_reraises_unexpected(monkeypatch, tmp_path):
+    cfg = _cfg(tmp_path, "a")
+    orchestrator = BatchOrchestrator([cfg])
+
+    def side_effect(cfg):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(orchestrator, "_run_single", side_effect)
+
+    with pytest.raises(RuntimeError):
+        orchestrator.run_all()
+
+
+def test_run_single_propagates_unexpected(monkeypatch, tmp_path):
+    cfg = _cfg(tmp_path, "a")
+    orchestrator = BatchOrchestrator([cfg])
+
+    dummy_ds = SimpleNamespace(config=SimpleNamespace(folder=str(tmp_path)))
+    arr = np.zeros((1, 3))
+
+    monkeypatch.setattr(
+        orchestrator.data_loader, "load_data", lambda cfg: (dummy_ds, arr, arr, arr)
+    )
+    monkeypatch.setattr(
+        orchestrator.outlier_handler, "exclude_outliers", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("bad")))
+    monkeypatch.setattr(
+        orchestrator.visualization_runner,
+        "generate_clouds_outliers",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        orchestrator.statistics_runner, "compute_statistics", lambda *a, **k: None
+    )
+
+    with pytest.raises(RuntimeError):
+        orchestrator._run_single(cfg)
+


### PR DESCRIPTION
## Summary
- handle only IOError and ValueError in BatchOrchestrator, re-raising anything unexpected
- add tests confirming that critical errors are surfaced

## Testing
- `PYTHONPATH=. pytest tests/test_pipeline/test_batch_orchestrator_errors.py -q`
- `PYTHONPATH=. pytest tests/test_pipeline/test_batch_orchestrator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e6f965a08323bc144059c1b4072f