### PR TITLE
Add centralized logging for main entry and rename utility

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,9 +17,18 @@ Run Pipeline using the command line:
                 --log_level INFO
 """
 
+import logging
+from m3c2.io.logging_utils import setup_logging
+
+
+logger = logging.getLogger(__name__)
+
 
 def main() -> None:
     """Execute the command line application."""
+    setup_logging()
+    logger.info("Starting M3C2 processing")
+
     from m3c2.cli.cli import CLIApp
 
     CLIApp().run()


### PR DESCRIPTION
## Summary
- configure logging in `main` using existing setup utility
- convert `rename_filename` to use module logger with detailed progress and warnings

## Testing
- `PYTHONPATH=. pytest`
- `PYTHONPATH=. pytest tests/test_io/filename_services/test_rename_filename.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5e8f5a0a083238ed1a55ddecfab76