### PR TITLE
Add logging around outlier exclusion

### DIFF
--- a/m3c2/pipeline/outlier_handler.py
+++ b/m3c2/pipeline/outlier_handler.py
@@ -5,6 +5,7 @@ import logging
 
 from m3c2.core.exclude_outliers import exclude_outliers
 
+# Module-level logger for this handler
 logger = logging.getLogger(__name__)
 
 
@@ -16,9 +17,16 @@ class OutlierHandler:
 
         This method is part of the public pipeline API.
         """
-        exclude_outliers(
-            data_folder=out_base,
-            ref_variant=tag,
-            method=cfg.outlier_detection_method,
-            outlier_multiplicator=cfg.outlier_multiplicator,
-        )
+        logger.info("[Outlier] Entferne Ausreißer …")
+        try:
+            exclude_outliers(
+                data_folder=out_base,
+                ref_variant=tag,
+                method=cfg.outlier_detection_method,
+                outlier_multiplicator=cfg.outlier_multiplicator,
+            )
+            logger.info("[Outlier] Entfernen abgeschlossen")
+        except Exception:
+            # Surface errors to callers while logging the stack trace
+            logger.exception("[Outlier] Fehler beim Entfernen der Ausreißer")
+            raise


### PR DESCRIPTION
## Summary
- log before and after outlier exclusion
- capture and surface errors using `logger.exception`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ScaleEstimator and VisualizationRunner missing private methods)*
- `python -m pytest tests/test_pipeline/test_outlier_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e911c3948323b4664073563bea04