### PR TITLE
feat: allow LOG_LEVEL env fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ python main.py
 
 Outputs, statistics, and logs are written to dataset folders and the `outputs/` directory.
 
+## Logging
+
+Control verbosity with the `--log_level` option or by setting the `LOG_LEVEL` environment variable. For example:
+
+```bash
+export LOG_LEVEL=DEBUG
+python main.py
+```
+
+If neither is provided, the log level defaults to `INFO`.
+
 ## Repository Structure
 - `config/` – dataclasses and plotting configuration
 - `datasource/` – unified loading of point cloud data

--- a/m3c2/cli/cli.py
+++ b/m3c2/cli/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import logging
 import json
+import os
 from pathlib import Path
 from typing import Any, List, Optional
 from m3c2.io.logging_utils import setup_logging
@@ -136,8 +137,8 @@ class CLIApp:
             "--log_level",
             type=str,
             choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-            default="INFO",
-            help="Logging level.",
+            default=None,
+            help="Logging level (falls back to LOG_LEVEL env var).",
         )
         return parser
 
@@ -158,6 +159,9 @@ class CLIApp:
                 parser.set_defaults(**defaults)
 
         args = parser.parse_args(argv)
+
+        if args.log_level is None:
+            args.log_level = os.getenv("LOG_LEVEL", "INFO")
 
         return args
 

--- a/m3c2/cli/plot_report.py
+++ b/m3c2/cli/plot_report.py
@@ -26,7 +26,7 @@ OUT_DIR = os.path.join(ROOT, "outputs", "MARS_Multi_Illumination", "plots")
 def main(data_dir: str = DATA_DIR, out_dir: str = OUT_DIR) -> tuple[str, str]:
     """Generate summary PDF reports for already generated plots."""
 
-    setup_logging()
+    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
     logger.info("Generating summary PDF reports from %s to %s", data_dir, out_dir)
 
     # Example configuration for generating additional grouped plots.

--- a/m3c2/cli/singlecloud_stats.py
+++ b/m3c2/cli/singlecloud_stats.py
@@ -1,6 +1,7 @@
 """Compute statistics for a single point cloud pair using ``StatisticsService``."""
 
 import logging
+import os
 
 from m3c2.core.statistics import StatisticsService
 from m3c2.io.logging_utils import setup_logging
@@ -24,7 +25,7 @@ def main(
 ) -> None:
     """Invoke :func:`StatisticsService.calc_single_cloud_stats` with defaults."""
 
-    setup_logging()
+    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
     logger.info(
         "Parameters received: folder_ids=%s, filename_mov=%s, filename_ref=%s, "
         "area_m2=%s, radius=%s, k=%s, sample_size=%s, use_convex_hull=%s, "

--- a/m3c2/io/filename_services/delete_filename.py
+++ b/m3c2/io/filename_services/delete_filename.py
@@ -35,7 +35,7 @@ def main():
     ap.add_argument("-n", "--dry-run", action="store_true", help="Nur anzeigen, nichts ändern")
     args = ap.parse_args()
 
-    setup_logging()
+    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
 
     base = Path(args.path).resolve()
     changed = skipped = 0

--- a/m3c2/io/filename_services/rename_filename.py
+++ b/m3c2/io/filename_services/rename_filename.py
@@ -39,7 +39,7 @@ def main():
     ap.add_argument("-n", "--dry-run", action="store_true", help="Nur anzeigen, nichts ändern")
     args = ap.parse_args()
 
-    setup_logging()
+    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
 
     base = Path(args.path).resolve()
     changed = skipped = 0

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ Run Pipeline using the command line:
 """
 
 import logging
+import os
 
 from m3c2.io.logging_utils import setup_logging
 
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     """Execute the command line application."""
-    setup_logging()
+    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
     logger.info("Starting CLI application")
 
     from m3c2.cli.cli import CLIApp

--- a/tests/test_cli/test_plot_report.py
+++ b/tests/test_cli/test_plot_report.py
@@ -16,7 +16,7 @@ def test_main_builds_pdfs(tmp_path, monkeypatch):
         "build_parts_pdf",
         staticmethod(fake_build_parts_pdf),
     )
-    monkeypatch.setattr(plot_report, "setup_logging", lambda: None)
+    monkeypatch.setattr(plot_report, "setup_logging", lambda level=None: None)
 
     pdf_incl, pdf_excl = plot_report.main(data_dir=str(tmp_path), out_dir=str(tmp_path))
 


### PR DESCRIPTION
## Summary
- support LOG_LEVEL environment fallback when --log_level is not given
- propagate resolved log level to setup_logging across modules
- document LOG_LEVEL environment variable in README

## Testing
- `PYTHONPATH=. pytest` *(fails: AttributeError: 'ScaleEstimator' object has no attribute '_determine_scales')*


------
https://chatgpt.com/codex/tasks/task_e_68b5ec64bae883239d3c3ba0445b9aae