### PR TITLE
Fix tests to use public pipeline methods

### DIFF
--- a/tests/test_pipeline/test_scale_estimator.py
+++ b/tests/test_pipeline/test_scale_estimator.py
@@ -98,7 +98,7 @@ def test_determine_scales_empty_scan_results(monkeypatch):
     estimator = ScaleEstimator(strategy_name="dummy")
 
     with pytest.raises(ValueError, match="keine Skalen"):
-        estimator._determine_scales(cfg, np.zeros((1, 3)))
+        estimator.determine_scales(cfg, np.zeros((1, 3)))
 
 
 def test_radius_scan_strategy_evaluate_radius_scale_plane():

--- a/tests/visualization_runner_test.py
+++ b/tests/visualization_runner_test.py
@@ -29,7 +29,7 @@ def test_generate_visuals_with_cloud(monkeypatch, tmp_path):
     monkeypatch.setattr(VisualizationService, "colorize", fake_colorize)
     monkeypatch.setattr(VisualizationService, "export_valid", fake_export_valid)
 
-    runner._generate_visuals(cfg, mov, distances, str(tmp_path), "tag")
+    runner.generate_visuals(cfg, mov, distances, str(tmp_path), "tag")
 
     assert "colorize" in calls
     assert "export_valid" in calls
@@ -57,7 +57,7 @@ def test_generate_visuals_without_cloud(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(VisualizationService, "export_valid", fake_export_valid)
 
     with caplog.at_level(logging.WARNING):
-        runner._generate_visuals(cfg, mov, distances, str(tmp_path), "tag")
+        runner.generate_visuals(cfg, mov, distances, str(tmp_path), "tag")
 
     assert "histogram" in calls
     assert "colorize" not in calls


### PR DESCRIPTION
## Summary
- Update scale estimator tests to call `determine_scales` instead of private `_determine_scales`
- Update visualization runner tests to call `generate_visuals` instead of private `_generate_visuals`

## Testing
- `PYTHONPATH=. pytest -q | tail -n 20 | nl -ba`

------
https://chatgpt.com/codex/tasks/task_e_68b5f03fb9ec832380b8da70224810f3