### PR TITLE
Respect LOG_LEVEL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ Outputs, statistics, and logs are written to dataset folders and the `outputs/` 
 
 ## Logging
 
-Control verbosity with the `--log_level` option or by setting the `LOG_LEVEL` environment variable. For example:
+Control verbosity with the `--log_level` option or by setting the `LOG_LEVEL`
+environment variable, which takes precedence over the value in `config.json`.
+For example:
 
 ```bash
 export LOG_LEVEL=DEBUG
 python main.py
 ```
 
-If neither is provided, the log level defaults to `INFO`.
+If neither is provided, the log level defaults to the `logging.level` entry in
+`config.json`.
 
 ## Repository Structure
 - `config/` – dataclasses and plotting configuration

--- a/m3c2/cli/cli.py
+++ b/m3c2/cli/cli.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import argparse
 import logging
 import json
-import os
 from pathlib import Path
 from typing import Any, List, Optional
-from m3c2.io.logging_utils import setup_logging
+
+from m3c2.io.logging_utils import resolve_log_level, setup_logging
 from m3c2.pipeline.batch_orchestrator import BatchOrchestrator
 from m3c2.config.pipeline_config import PipelineConfig
 
@@ -156,12 +156,10 @@ class CLIApp:
                 data = {}
             defaults = data.get("arguments", data)
             if isinstance(defaults, dict):
+                defaults.pop("log_level", None)
                 parser.set_defaults(**defaults)
 
         args = parser.parse_args(argv)
-
-        if args.log_level is None:
-            args.log_level = os.getenv("LOG_LEVEL", "INFO")
 
         return args
 
@@ -204,7 +202,7 @@ class CLIApp:
         arg = self.parse_args(argv)
 
         log_file = "logs/orchestration.log"
-        setup_logging(level=arg.log_level, log_file=log_file)
+        setup_logging(level=resolve_log_level(arg.log_level), log_file=log_file)
 
         base_dir = Path(arg.data_dir).expanduser().resolve()
         

--- a/m3c2/cli/comparedist_plots.py
+++ b/m3c2/cli/comparedist_plots.py
@@ -8,6 +8,8 @@ import logging
 import sys
 import os
 
+from m3c2.io.logging_utils import resolve_log_level, setup_logging
+
 logger = logging.getLogger(__name__)
 
 # Allow absolute imports when the script is executed directly.
@@ -24,6 +26,8 @@ def main(
     outdir: str = "outputs",
 ) -> None:
     """Configure and create distance comparison plots."""
+
+    setup_logging(level=resolve_log_level())
 
     folder_ids = folder_ids or ["0342-0349"]
     ref_variants = ref_variants or ["ref", "ref_ai"]

--- a/m3c2/cli/outlier_plots.py
+++ b/m3c2/cli/outlier_plots.py
@@ -1,11 +1,15 @@
 """Visualize distance distributions including various outlier filtering methods.
 
 The script reads distance files for different processing variants and produces
-boxplots comparing all distances with several inlier-selection techniques.
-"""
+boxplots comparing all distances with several inlier-selection techniques."""
+import logging
 import os
 import numpy as np
 import matplotlib.pyplot as plt
+
+from m3c2.io.logging_utils import resolve_log_level, setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def main(
@@ -15,6 +19,8 @@ def main(
     outdir: str | None = None,
 ) -> None:
     """Create boxplots comparing full and inlier-filtered distances."""
+
+    setup_logging(level=resolve_log_level())
 
     variants = variants or [
         ("ref", "python_ref_m3c2_distances.txt"),

--- a/m3c2/cli/plot_report.py
+++ b/m3c2/cli/plot_report.py
@@ -15,7 +15,7 @@ if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
 from m3c2.visualization.plot_service import PlotService
-from m3c2.io.logging_utils import setup_logging
+from m3c2.io.logging_utils import resolve_log_level, setup_logging
 from m3c2.config.plot_config import PlotOptions
 
 # Input and output directories for the Multi-Illumination dataset.
@@ -26,7 +26,7 @@ OUT_DIR = os.path.join(ROOT, "outputs", "MARS_Multi_Illumination", "plots")
 def main(data_dir: str = DATA_DIR, out_dir: str = OUT_DIR) -> tuple[str, str]:
     """Generate summary PDF reports for already generated plots."""
 
-    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
+    setup_logging(level=resolve_log_level())
     logger.info("Generating summary PDF reports from %s to %s", data_dir, out_dir)
 
     # Example configuration for generating additional grouped plots.

--- a/m3c2/cli/singlecloud_stats.py
+++ b/m3c2/cli/singlecloud_stats.py
@@ -1,10 +1,9 @@
 """Compute statistics for a single point cloud pair using ``StatisticsService``."""
 
 import logging
-import os
 
 from m3c2.core.statistics import StatisticsService
-from m3c2.io.logging_utils import setup_logging
+from m3c2.io.logging_utils import resolve_log_level, setup_logging
 
 
 logger = logging.getLogger(__name__)
@@ -25,7 +24,7 @@ def main(
 ) -> None:
     """Invoke :func:`StatisticsService.calc_single_cloud_stats` with defaults."""
 
-    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
+    setup_logging(level=resolve_log_level())
     logger.info(
         "Parameters received: folder_ids=%s, filename_mov=%s, filename_ref=%s, "
         "area_m2=%s, radius=%s, k=%s, sample_size=%s, use_convex_hull=%s, "

--- a/m3c2/io/__init__.py
+++ b/m3c2/io/__init__.py
@@ -1,6 +1,6 @@
 """Infrastructure layer: file I/O, logging utilities, and helpers."""
 
-from .logging_utils import setup_logging
+from .logging_utils import resolve_log_level, setup_logging
 
-__all__ = ["setup_logging"]
+__all__ = ["resolve_log_level", "setup_logging"]
 

--- a/m3c2/io/filename_services/delete_filename.py
+++ b/m3c2/io/filename_services/delete_filename.py
@@ -3,7 +3,7 @@
 import argparse, os, logging
 from pathlib import Path
 
-from m3c2.io.logging_utils import setup_logging
+from m3c2.io.logging_utils import resolve_log_level, setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ def main():
     ap.add_argument("-n", "--dry-run", action="store_true", help="Nur anzeigen, nichts ändern")
     args = ap.parse_args()
 
-    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
+    setup_logging(level=resolve_log_level())
 
     base = Path(args.path).resolve()
     changed = skipped = 0

--- a/m3c2/io/filename_services/rename_filename.py
+++ b/m3c2/io/filename_services/rename_filename.py
@@ -3,7 +3,7 @@
 import re, argparse, os, logging
 from pathlib import Path
 
-from m3c2.io.logging_utils import setup_logging
+from m3c2.io.logging_utils import resolve_log_level, setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ def main():
     ap.add_argument("-n", "--dry-run", action="store_true", help="Nur anzeigen, nichts ändern")
     args = ap.parse_args()
 
-    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
+    setup_logging(level=resolve_log_level())
 
     base = Path(args.path).resolve()
     changed = skipped = 0

--- a/main.py
+++ b/main.py
@@ -18,16 +18,15 @@ Run Pipeline using the command line:
 """
 
 import logging
-import os
 
-from m3c2.io.logging_utils import setup_logging
+from m3c2.io.logging_utils import resolve_log_level, setup_logging
 
 logger = logging.getLogger(__name__)
 
 
 def main() -> None:
     """Execute the command line application."""
-    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
+    setup_logging(level=resolve_log_level())
     logger.info("Starting CLI application")
 
     from m3c2.cli.cli import CLIApp


### PR DESCRIPTION
## Summary
- Default logging configuration pulls level from `config.json` and honors `LOG_LEVEL` overrides
- Pass the resolved level to `setup_logging()` in all entry points
- Document the `LOG_LEVEL` environment variable and config fallback in the README

## Testing
- `PYTHONPATH=/workspace/M3C2 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5f103dc4083238aad7b12af730725