### PR TITLE
Add descriptive docstring for m3c2 package

### DIFF
--- a/m3c2/__init__.py
+++ b/m3c2/__init__.py
@@ -1,0 +1,7 @@
+"""Top-level package for the M3C2 point cloud processing pipeline.
+
+The package orchestrates loading of point cloud data, parameter estimation,
+distance computation, statistical analysis, visualization, and batch
+processing using the Multiscale Model to Model Cloud Comparison (M3C2)
+algorithm.
+"""


### PR DESCRIPTION
## Summary
- Add module docstring to `m3c2/__init__.py` describing package purpose

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b680d6c5a0832380292b0c34fbd20b