### PR TITLE
Add docstring for CLI package

### DIFF
--- a/m3c2/cli/__init__.py
+++ b/m3c2/cli/__init__.py
@@ -1,1 +1,4 @@
-# zentrale CLI (`m3c2.cli:main`)
+"""Command line interface package for M3C2.
+
+Provides entry points for command-line tools, with `m3c2.cli:main` as the primary interface.
+"""


### PR DESCRIPTION
## Summary
- document CLI package with a module-level docstring

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b680d7e9388323a12ba5cd29aceb4e