### PR TITLE
Add docstring for configuration package

### DIFF
--- a/m3c2/config/__init__.py
+++ b/m3c2/config/__init__.py
@@ -1,1 +1,1 @@
-# gemeinsame Konfigurationsobjekte
+"""Common configuration objects for the m3c2 package."""


### PR DESCRIPTION
## Summary
- Document configuration package with a concise module-level docstring.

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b680da842483238e40970f6aeb9dae