### PR TITLE
Add module docstring for core datatypes module

### DIFF
--- a/m3c2/core/datatypes.py
+++ b/m3c2/core/datatypes.py
@@ -1,0 +1,9 @@
+"""Light-weight data structures used throughout the M3C2 core package.
+
+The module acts as a central place for small container classes and type
+aliases that are shared between different processing steps. Examples of
+structures that belong here include representations of bounding boxes,
+parameter estimation results, or outputs of outlier detection routines.
+Keeping these definitions together helps to avoid circular imports and
+provides a single reference point for the project.
+"""


### PR DESCRIPTION
## Summary
- document purpose of `m3c2.core.datatypes`

## Testing
- `pytest` *(fails: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b680de1ee0832390924b7e0b538637