### PR TITLE
Add docstring for timestamp generation helper

### DIFF
--- a/m3c2/core/statistics/exporters.py
+++ b/m3c2/core/statistics/exporters.py
@@ -34,6 +34,12 @@ logger = logging.getLogger(__name__)
 
 
 def _now_timestamp() -> str:
+    """Return the current time formatted as ``YYYY-MM-DD HH:MM:SS``.
+
+    The timestamp is generated using :func:`datetime.now` and formatted with
+    :func:`strftime` so that exported statistics include a consistent,
+    human-readable creation time.
+    """
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 


### PR DESCRIPTION
## Summary
- clarify how timestamp strings are generated for exported statistics

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b680e63fbc8323ac0df290ceb8adbd