### PR TITLE
Add module docstring for outlier utilities

### DIFF
--- a/m3c2/core/statistics/outliers.py
+++ b/m3c2/core/statistics/outliers.py
@@ -1,3 +1,11 @@
+"""Outlier detection and analysis utilities.
+
+This module provides helpers to compute boolean masks identifying outliers
+based on various statistical measures (RMSE, interquartile range, standard
+deviation and NMAD) as well as functions to summarize inlier and outlier
+distributions.
+"""
+
 from __future__ import annotations
 
 from typing import Dict


### PR DESCRIPTION
## Summary
- document outlier detection helpers with a module docstring

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'm3c2')

------
https://chatgpt.com/codex/tasks/task_e_68b680e8cf94832399ed26fe6b06504a