### PR TITLE
Document _resolve in statistics service

### DIFF
--- a/m3c2/core/statistics/service.py
+++ b/m3c2/core/statistics/service.py
@@ -348,6 +348,21 @@ class StatisticsService:
 
     @staticmethod
     def _resolve(fid: str, filename: str) -> str:
+        """Resolve the path for a statistics file.
+
+        The function first checks whether ``filename`` exists inside the
+        directory identified by ``fid``.  If the file is found there, that
+        path is returned.  Otherwise, the function falls back to the
+        repository's ``data`` directory and constructs the path as
+        ``data/fid/filename``.
+
+        Args:
+            fid: Identifier of the dataset, used as directory name.
+            filename: Name of the file to resolve.
+
+        Returns:
+            The resolved file path.
+        """
         p1 = os.path.join(fid, filename)
         if os.path.exists(p1):
             return p1


### PR DESCRIPTION
## Summary
- document statistics service's `_resolve` helper function

## Testing
- `PYTHONPATH=. pytest tests/test_core -q`


------
https://chatgpt.com/codex/tasks/task_e_68b680ee20fc8323864f24ecaafab3d4