### PR TITLE
docs: clarify GUI start handler

### DIFF
--- a/m3c2/gui/argparse_gui.py
+++ b/m3c2/gui/argparse_gui.py
@@ -56,6 +56,14 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
         row += 1
 
     def on_start() -> None:
+        """Handle the start event by collecting arguments and executing the main function.
+
+        The callback gathers values from all GUI widgets, assembles them into an
+        ``argv`` list, parses them using the provided ``argparse`` parser and, if
+        successful, closes the GUI and invokes ``main_func`` with the resulting
+        namespace.  Any parsing errors are reported via a message box instead of
+        raising ``SystemExit``.
+        """
         argv: list[str] = []
         for action in parser._actions:
             if isinstance(action, argparse._HelpAction):


### PR DESCRIPTION
## Summary
- add a detailed docstring for the `on_start` callback in the argument parser GUI

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b680f142e08323841efbf075f8aa87