### PR TITLE
Add docstring for argparse GUI cancel handler

### DIFF
--- a/m3c2/gui/argparse_gui.py
+++ b/m3c2/gui/argparse_gui.py
@@ -99,6 +99,7 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
             messagebox.showerror("Fehler", str(exc))
 
     def on_cancel() -> None:
+        """Close the GUI without executing the selected command."""
         logger.info("Cancel pressed")
         root.destroy()
 


### PR DESCRIPTION
## Summary
- document cancel button behavior in argparse GUI

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b680f282308323927ca9f9c9941d4e