### PR TITLE
Add docstring for mov_base

### DIFF
--- a/m3c2/io/datasource.py
+++ b/m3c2/io/datasource.py
@@ -38,6 +38,13 @@ class DataSource:
     # path helpers
     @property
     def mov_base(self) -> Path:
+        """Base path of the moving epoch file.
+
+        Combines the configured folder and moving filename base without
+        an extension, resulting in the path used to detect the moving
+        epoch's data file.
+        """
+
         return Path(self.config.folder) / self.config.mov_basename
 
     @property


### PR DESCRIPTION
## Summary
- document mov_base property to clarify returned moving epoch path

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'm3c2')

------
https://chatgpt.com/codex/tasks/task_e_68b680f3c2e88323a857a2ee4ae17efb