### PR TITLE
docs: explain reference base path logic

### DIFF
--- a/m3c2/io/datasource.py
+++ b/m3c2/io/datasource.py
@@ -42,6 +42,13 @@ class DataSource:
 
     @property
     def ref_base(self) -> Path:
+        """Return the base path for the reference epoch.
+
+        The path is constructed by combining the configured data folder with
+        the reference file's base name. The resulting path intentionally lacks
+        a file extension; downstream loaders append the appropriate suffix when
+        searching for the actual reference data file.
+        """
         return Path(self.config.folder) / self.config.ref_basename
 
     def _detect(self, base: Path) -> tuple[str | None, Path | None]:


### PR DESCRIPTION
## Summary
- document how reference base path is constructed in datasource

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b680f4721483239045d4a6dbddf4ef