### PR TITLE
Add documentation for cloud statistics comments sheet

### DIFF
--- a/m3c2/io/excel_writer/comments_stats_clouds.py
+++ b/m3c2/io/excel_writer/comments_stats_clouds.py
@@ -1,3 +1,11 @@
+"""Utilities to annotate cloud statistics worksheets.
+
+This module attaches descriptive comments to the headers of a *CloudStats*
+Excel sheet.  Each column in the sheet represents a point-cloud metric and the
+inserted comments explain how those metrics were derived, aiding users when
+creating or inspecting cloud statistics tables.
+"""
+
 import logging
 import re
 from openpyxl import load_workbook


### PR DESCRIPTION
## Summary
- document cloud stats comment writer with a descriptive module docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b680f681208323824cea88e1be2d3a