### PR TITLE
docs: add CLI docstring for deletion tool

### DIFF
--- a/m3c2/io/filename_services/delete_filename.py
+++ b/m3c2/io/filename_services/delete_filename.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
 # remove_cloud_token.py
+"""CLI tool for removing `_cloud` tokens from file and directory names.
+
+The script walks a base directory and renames entries by deleting the
+`_cloud` token from their names. It supports recursive traversal,
+optionally includes directory names in the renaming process and offers a
+dry-run mode to preview changes without modifying the filesystem.
+"""
+
 import argparse, os, logging
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- document CLI that removes `_cloud` tokens from filenames and directories

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b680fa78508323b0e75e00e8a97ce0