### PR TITLE
Add exporter utilities docstring

### DIFF
--- a/m3c2/core/statistics/exporters.py
+++ b/m3c2/core/statistics/exporters.py
@@ -1,3 +1,10 @@
+"""Export utilities for statistics tables.
+
+This module provides helper functions to persist statistical results in a
+canonical column order. Data frames can be appended to Excel or JSON files
+so that successive runs build a consolidated record of metrics.
+"""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- add module-level docstring explaining statistical export helpers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b680e5d47483239be6fc9ecf972ef8