### PR TITLE
Add package overview docstring for core components

### DIFF
--- a/m3c2/core/__init__.py
+++ b/m3c2/core/__init__.py
@@ -1,1 +1,8 @@
- # Domain‑Code
+"""Core components for the M3C2 package.
+
+This subpackage collects the fundamental building blocks for the
+M3C2 workflow, including utilities for bounding box handling, data
+type definitions, outlier exclusion routines, parameter estimation,
+and statistical calculations.
+"""
+


### PR DESCRIPTION
## Summary
- document core package with a top-level docstring

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b680dd1a1c8323b47d76268c6425f0