### PR TITLE
Move component_factory docstring above future import

### DIFF
--- a/m3c2/pipeline/component_factory.py
+++ b/m3c2/pipeline/component_factory.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
 """Factory for creating pipeline components used by :class:`BatchOrchestrator`."""
+
+from __future__ import annotations
 
 import logging
 


### PR DESCRIPTION
## Summary
- place module docstring above `from __future__ import annotations` in `component_factory`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b69b1022188323adbb95556fc378aa