### PR TITLE
Document PipelineComponentFactory initialization parameters

### DIFF
--- a/m3c2/pipeline/component_factory.py
+++ b/m3c2/pipeline/component_factory.py
@@ -18,6 +18,16 @@ class PipelineComponentFactory:
     """Create configured instances of pipeline helper classes."""
 
     def __init__(self, strategy_name: str, output_format: str) -> None:
+        """Configure the factory with strategy and export format.
+
+        Parameters
+        ----------
+        strategy_name:
+            Name of the scale estimation strategy used by created components.
+        output_format:
+            Output format for statistics produced in later pipeline stages,
+            e.g. ``"excel"`` or ``"json"``.
+        """
         self.strategy_name = strategy_name
         self.output_format = output_format
         logger.debug(


### PR DESCRIPTION
## Summary
- clarify PipelineComponentFactory initialization by adding docstring for strategy and output format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*
- `PYTHONPATH=. pytest tests/test_pipeline/test_component_factory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b1122b4832399dbd316712d137d