### PR TITLE
Add docstring for data loader creation

### DIFF
--- a/m3c2/pipeline/component_factory.py
+++ b/m3c2/pipeline/component_factory.py
@@ -27,6 +27,8 @@ class PipelineComponentFactory:
         )
 
     def create_data_loader(self) -> DataLoader:
+        """Return a new :class:`DataLoader` instance."""
+
         logger.debug("Creating %s", DataLoader.__name__)
         return DataLoader()
 


### PR DESCRIPTION
## Summary
- Document `PipelineComponentFactory.create_data_loader` to clarify it returns a new `DataLoader` instance.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*


------
https://chatgpt.com/codex/tasks/task_e_68b69b122c2c832396837a8880625a47