### PR TITLE
Add docstring for scale estimator creation

### DIFF
--- a/m3c2/pipeline/component_factory.py
+++ b/m3c2/pipeline/component_factory.py
@@ -31,6 +31,17 @@ class PipelineComponentFactory:
         return DataLoader()
 
     def create_scale_estimator(self) -> ScaleEstimator:
+        """Create a :class:`ScaleEstimator` for the configured strategy.
+
+        The factory's ``strategy_name`` determines which scale scanning
+        strategy the estimator will employ to derive the normal and
+        projection scales for the M3C2 algorithm.
+
+        Returns
+        -------
+        ScaleEstimator
+            Estimator instance initialised with the selected strategy.
+        """
         logger.debug("Creating %s", ScaleEstimator.__name__)
         return ScaleEstimator(strategy_name=self.strategy_name)
 


### PR DESCRIPTION
## Summary
- document `create_scale_estimator` to clarify strategy selection and returned estimator

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b12d9088323a199f73a09754e32