### PR TITLE
Add docstring for M3C2 executor factory method

### DIFF
--- a/m3c2/pipeline/component_factory.py
+++ b/m3c2/pipeline/component_factory.py
@@ -35,6 +35,7 @@ class PipelineComponentFactory:
         return ScaleEstimator(strategy_name=self.strategy_name)
 
     def create_m3c2_executor(self) -> M3C2Executor:
+        """Instantiate the :class:`M3C2Executor` used for processing."""
         logger.debug("Creating %s", M3C2Executor.__name__)
         return M3C2Executor()
 


### PR DESCRIPTION
## Summary
- Document that `create_m3c2_executor` instantiates an `M3C2Executor`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b141a988323b3b2c467d0e73d13