### PR TITLE
Document outlier handler factory method

### DIFF
--- a/m3c2/pipeline/component_factory.py
+++ b/m3c2/pipeline/component_factory.py
@@ -39,6 +39,13 @@ class PipelineComponentFactory:
         return M3C2Executor()
 
     def create_outlier_handler(self) -> OutlierHandler:
+        """Instantiate an :class:`OutlierHandler` for removing statistical outliers.
+
+        The returned handler applies the configured outlier detection method to the
+        generated M3C2 results and filters out measurements deemed to be outliers.
+        This ensures downstream statistics and visualizations are based on
+        cleaned data.
+        """
         logger.debug("Creating %s", OutlierHandler.__name__)
         return OutlierHandler()
 


### PR DESCRIPTION
## Summary
- Add docstring for `create_outlier_handler` detailing its role in instantiating the `OutlierHandler`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b15e9908323955641387389cd02