### PR TITLE
doc: document statistics runner creation

### DIFF
--- a/m3c2/pipeline/component_factory.py
+++ b/m3c2/pipeline/component_factory.py
@@ -43,6 +43,12 @@ class PipelineComponentFactory:
         return OutlierHandler()
 
     def create_statistics_runner(self) -> StatisticsRunner:
+        """Create a :class:`StatisticsRunner` honoring the output format.
+
+        The returned runner serializes computed statistics either as Excel
+        spreadsheets or JSON files depending on the ``output_format`` specified
+        when this factory was instantiated.
+        """
         logger.debug("Creating %s", StatisticsRunner.__name__)
         return StatisticsRunner(self.output_format)
 


### PR DESCRIPTION
## Summary
- clarify how PipelineComponentFactory configures StatisticsRunner output format

## Testing
- `PYTHONPATH=$PYTHONPATH:$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69b1662fc8323a13b690fcc6fb034