### PR TITLE
Move outlier handler docstring above future import

### DIFF
--- a/m3c2/pipeline/outlier_handler.py
+++ b/m3c2/pipeline/outlier_handler.py
@@ -1,5 +1,5 @@
-from __future__ import annotations
 """Handle exclusion of statistical outliers."""
+from __future__ import annotations
 
 import logging
 


### PR DESCRIPTION
## Summary
- place module docstring before `from __future__ import annotations` in outlier handler

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*


------
https://chatgpt.com/codex/tasks/task_e_68b69b1b1f508323b75b197124319927