### PR TITLE
Move module docstring before future import

### DIFF
--- a/m3c2/pipeline/scale_estimator.py
+++ b/m3c2/pipeline/scale_estimator.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
 """Determine optimal scales for the M3C2 algorithm."""
+
+from __future__ import annotations
 
 import logging
 import time


### PR DESCRIPTION
## Summary
- position the module docstring above the `from __future__ import annotations` import in `scale_estimator`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b20733883238a336b9cf1bd470f