### PR TITLE
Reorder module docstring before future annotations import

### DIFF
--- a/m3c2/pipeline/statistics_runner.py
+++ b/m3c2/pipeline/statistics_runner.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
 """Compute and export statistical summaries for the M3C2 pipeline."""
+
+from __future__ import annotations
 
 import logging
 import os


### PR DESCRIPTION
## Summary
- move statistics_runner module docstring above `from __future__ import annotations`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b2278288323b2e7941f4b775344