### PR TITLE
Document output format parameter

### DIFF
--- a/m3c2/pipeline/statistics_runner.py
+++ b/m3c2/pipeline/statistics_runner.py
@@ -13,6 +13,13 @@ class StatisticsRunner:
     """Run various statistical evaluations depending on configuration."""
 
     def __init__(self, output_format: str) -> None:
+        """Initialize the statistics runner.
+
+        Args:
+            output_format: Desired format for the exported statistics. Use
+                ``"excel"`` to create an Excel workbook or ``"json"`` to write
+                a JSON file.
+        """
         self.output_format = output_format
 
     def compute_statistics(self, cfg, ref, tag: str) -> None:


### PR DESCRIPTION
## Summary
- Clarify how to specify the output format for statistics via a new docstring in `StatisticsRunner.__init__`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b238a7483239aac04da991c1a42