### PR TITLE
Clarify statistics runner docstring

### DIFF
--- a/m3c2/pipeline/statistics_runner.py
+++ b/m3c2/pipeline/statistics_runner.py
@@ -18,6 +18,36 @@ class StatisticsRunner:
     def compute_statistics(self, cfg, ref, tag: str) -> None:
         """Compute M3C2 statistics for a job.
 
+        Parameters
+        ----------
+        cfg
+            Configuration object describing the current job.  The runner
+            expects attributes such as :attr:`stats_singleordistance`,
+            :attr:`folder_id`, :attr:`project` and various filenames.
+        ref
+            Optional reference information.  The parameter is currently not
+            used but retained for API compatibility with other pipeline
+            components.
+        tag : str
+            Identifier for the reference cloud when evaluating distance based
+            statistics.
+
+        Branching
+        ---------
+        If ``cfg.stats_singleordistance`` is ``"distance"`` the method
+        computes statistics on the distances between two clouds using
+        :func:`StatisticsService.compute_m3c2_statistics`.  When the value is
+        ``"single"`` statistics for individual clouds are computed via
+        :func:`StatisticsService.calc_single_cloud_stats`.
+
+        Output
+        ------
+        Results are stored in ``outputs/{project}_output``.  Distance
+        statistics are written to ``{project}_m3c2_stats_distances`` and
+        single cloud statistics to ``{project}_m3c2_stats_clouds``.  The
+        extension is either ``.xlsx`` or ``.json`` depending on
+        ``self.output_format``.
+
         This method is part of the public pipeline API.
         """
         if cfg.stats_singleordistance == "distance":


### PR DESCRIPTION
## Summary
- document parameters `cfg`, `ref`, `tag` for `compute_statistics`
- explain branching paths and output destinations in docstring

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b2465ec8323a4edc0ab2de42b98