### PR TITLE
docs: add module docstring to Bland-Altman plotter

### DIFF
--- a/m3c2/visualization/bland_altman_plotter.py
+++ b/m3c2/visualization/bland_altman_plotter.py
@@ -1,3 +1,11 @@
+"""Bland–Altman plot creation utilities.
+
+This module loads paired distance measurements for given folders and
+reference variants and visualizes their agreement using Bland–Altman
+scatter plots. It computes the mean difference and 95% limits of agreement
+and saves the resulting plots for further analysis.
+"""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- document `bland_altman_plotter` module with an overview of how it generates Bland–Altman plots

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b270a5483238593ef12acd6c460