### PR TITLE
Clarify Bland–Altman plotter documentation

### DIFF
--- a/m3c2/visualization/bland_altman_plotter.py
+++ b/m3c2/visualization/bland_altman_plotter.py
@@ -17,7 +17,22 @@ def bland_altman_plot(
     ref_variants: List[str],
     outdir: str = "BlandAltman",
 ) -> None:
-    """Create Bland–Altman plots for given folders and reference variants."""
+    """Create Bland–Altman plots for given folders and reference variants.
+
+    Parameters
+    ----------
+    folder_ids : List[str]
+        Identifiers of the folders whose comparison data should be plotted.
+    ref_variants : List[str]
+        Names of the two reference variants to compare. Must contain exactly
+        two entries.
+    outdir : str, optional
+        Directory where the generated plots are stored. Defaults to
+        ``"BlandAltman"``.
+
+    The function saves one PNG per folder in ``outdir`` with the filename
+    pattern ``bland_altman_<folder>_<ref1>_vs_<ref2>.png``.
+    """
     if len(ref_variants) != 2:
         raise ValueError("ref_variants must contain exactly two entries")
 


### PR DESCRIPTION
## Summary
- expand `bland_altman_plot` docstring to describe folder ids, reference variants, output directory, and saved PNG pattern

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69b2811b8832394c37dd1744ea4f7