### PR TITLE
Add docstring for tag index conversion in distance loader

### DIFF
--- a/m3c2/visualization/distance_loader.py
+++ b/m3c2/visualization/distance_loader.py
@@ -54,6 +54,14 @@ def scan_distance_files_by_index(data_dir: str, versions=("python", "CC")) -> Tu
     )
 
     def idx_of(tag: str) -> int:
+        """Return the numerical index encoded in a tag.
+
+        Tags follow the pattern ``'<prefix>-<num>'`` where ``<prefix>`` is
+        either ``a`` or ``b`` and ``<num>`` is an integer.  An optional
+        ``-AI`` suffix may be present.  This helper extracts the ``<num>``
+        portion and returns it as an integer, or ``-1`` if the tag does not
+        match the expected format.
+        """
         m = re.match(r'^[ab]-(\d+)(?:-AI)?$', tag, re.IGNORECASE)
         return int(m.group(1)) if m else -1
 


### PR DESCRIPTION
## Summary
- Explain tag-to-index conversion in `scan_distance_files_by_index`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b69b2ad8508323869f2bf71d6e9a90