### PR TITLE
Add docstring to linear regression plotter module

### DIFF
--- a/m3c2/visualization/linear_regression_plotter.py
+++ b/m3c2/visualization/linear_regression_plotter.py
@@ -1,3 +1,10 @@
+"""OLS plotting utility for visualizing linear regression between two variants.
+
+This module loads paired reference measurements, fits an ordinary least squares
+regression with confidence intervals, and saves the resulting comparison
+plots for each folder.
+"""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- Document the linear regression plotter module with an overview of the OLS plotting utility.

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b69b2c619c832396031fc736b27716