### PR TITLE
docs: clarify case classification in distance loader

### DIFF
--- a/m3c2/visualization/distance_loader.py
+++ b/m3c2/visualization/distance_loader.py
@@ -58,6 +58,21 @@ def scan_distance_files_by_index(data_dir: str, versions=("python", "CC")) -> Tu
         return int(m.group(1)) if m else -1
 
     def to_case_and_label(mov: str, ref: str, i: int) -> tuple[str, str]:
+        """Derive case identifier and label for a dataset comparison.
+
+        Both *mov* and *ref* contain tags such as ``"a-1"`` or
+        ``"b-2-AI"``.  The presence of the ``"-AI"`` suffix determines the
+        classification into one of four cases:
+
+        * ``CASE1`` – neither tag includes ``"-AI"``.
+        * ``CASE2`` – only the reference tag includes ``"-AI"``.
+        * ``CASE3`` – only the moving tag includes ``"-AI"``.
+        * ``CASE4`` – both tags include ``"-AI"``.
+
+        The returned label mirrors the underlying tags using the pattern
+        ``"a-{i}... vs b-{i}..."``.
+        """
+
         mov_ai = "-AI" in mov
         ref_ai = "-AI" in ref
         if not mov_ai and not ref_ai:


### PR DESCRIPTION
## Summary
- document case classification logic used when labeling dataset comparisons

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b69b2c0c4c83238cafe72470ff2b1a