### PR TITLE
Document _square_limits in linear_regression_plotter

### DIFF
--- a/m3c2/visualization/linear_regression_plotter.py
+++ b/m3c2/visualization/linear_regression_plotter.py
@@ -13,6 +13,21 @@ logger = logging.getLogger(__name__)
 
 
 def _square_limits(x: np.ndarray, y: np.ndarray, pad: float = 0.05):
+    """Return square axis limits covering the ``x`` and ``y`` data.
+
+    Parameters
+    ----------
+    x, y:
+        Arrays of x and y coordinates.
+    pad:
+        Fractional padding applied to the half-width of the square.
+
+    Returns
+    -------
+    tuple[tuple[float, float], tuple[float, float]]
+        ``(x_limits, y_limits)`` where each is a ``(min, max)`` tuple.
+    """
+
     x_min, x_max = float(np.min(x)), float(np.max(x))
     y_min, y_max = float(np.min(y)), float(np.max(y))
     v_min = min(x_min, y_min)


### PR DESCRIPTION
## Summary
- Clarify the helper `_square_limits` by adding a docstring outlining its parameters and return values

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69b2d9cb883239f2053900127c32a