### PR TITLE
docs: add report builder module docstring

### DIFF
--- a/m3c2/visualization/report_builder.py
+++ b/m3c2/visualization/report_builder.py
@@ -1,3 +1,10 @@
+"""PDF and plot generation utilities for M3C2 reports.
+
+This module gathers helper functions that load distance measurements,
+compute statistics, and create visualizations which are combined into
+multi-page PDF documents.
+"""
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- add module-level docstring to `report_builder.py` describing its PDF and plot generation utilities

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69b3e20d4832394b61783b6a6548c