### PR TITLE
Add Weibull overlay docstring

### DIFF
--- a/m3c2/visualization/overlay_plotter.py
+++ b/m3c2/visualization/overlay_plotter.py
@@ -100,6 +100,14 @@ def plot_overlay_weibull(
     title_text: str | None = None,
     labels_order: List[str] | None = None,
 ) -> None:
+    """Fit Weibull distributions and plot their probability densities.
+
+    Each array in ``data`` is fitted with :func:`scipy.stats.weibull_min.fit`
+    to estimate the shape, location, and scale parameters of a Weibull
+    distribution.  The resulting probability density functions are evaluated
+    on ``x`` and plotted together.  The combined overlay is written to
+    ``{fid}_{fname}_OverlayWeibullFits.png`` inside ``outdir``.
+    """
     weibull_params: Dict[str, Tuple[float, float, float]] = {}
     for v, arr in data.items():
         try:


### PR DESCRIPTION
## Summary
- document Weibull overlay plotting and output in `plot_overlay_weibull`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*
- `PYTHONPATH=/workspace/M3C2 pytest test_visualization/test_overlay_plotter.py`


------
https://chatgpt.com/codex/tasks/task_e_68b69b30f3c48323a9273ddbaeaa86c9