### PR TITLE
Add docstring clarifying label ordering helper

### DIFF
--- a/m3c2/visualization/plot_service.py
+++ b/m3c2/visualization/plot_service.py
@@ -39,6 +39,23 @@ class PlotService:
     # ------------------------------------------------------------------
     @staticmethod
     def _labels_by_case_map(case_map: Dict[str, str], case_order: Tuple[str, ...] | None = None) -> List[str]:
+        """Order labels according to a mapping of labels to cases.
+
+        Parameters
+        ----------
+        case_map:
+            Mapping from label names to a case identifier.
+        case_order:
+            Optional sequence describing the desired order of cases. If not
+            provided, :attr:`CASE_ORDER` is used.
+
+        Returns
+        -------
+        list[str]
+            Labels sorted first by the order of their case as specified by
+            ``case_order`` and within each case by their insertion order in
+            ``case_map``.
+        """
         order = case_order or PlotService.CASE_ORDER
         labels: List[str] = []
         for c in order:


### PR DESCRIPTION
## Summary
- Document `_labels_by_case_map` helper in `plot_service`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b37f304832398d673cf43dced8f