### PR TITLE
Document data ordering in _reorder_data

### DIFF
--- a/m3c2/visualization/plot_service.py
+++ b/m3c2/visualization/plot_service.py
@@ -47,6 +47,13 @@ class PlotService:
 
     @staticmethod
     def _reorder_data(data: Dict[str, np.ndarray], labels_order: List[str]) -> "OrderedDict[str, np.ndarray]":
+        """Return ``data`` sorted according to ``labels_order``.
+
+        An :class:`~collections.OrderedDict` is constructed whose items follow
+        the sequence given by ``labels_order``. Only labels present in
+        ``data`` are included, ensuring that downstream plotting receives the
+        arrays in a predictable order.
+        """
         return OrderedDict((lbl, data[lbl]) for lbl in labels_order if lbl in data)
 
     @staticmethod


### PR DESCRIPTION
## Summary
- clarify ordered behavior of `_reorder_data`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69b3911a08323baa441b53e1cfb35