### PR TITLE
docs: document overlay_plots wrapper

### DIFF
--- a/m3c2/visualization/plot_service.py
+++ b/m3c2/visualization/plot_service.py
@@ -272,6 +272,12 @@ class PlotService:
 
     @staticmethod
     def overlay_plots(config: PlotConfig, options: PlotOptions) -> None:
+        """Wrapper exposing :func:`report_builder.overlay_plots`.
+
+        The heavy lifting is done by ``report_builder.overlay_plots``; this
+        method merely forwards the call so that overlay plotting is available
+        via :class:`PlotService`.
+        """
         _overlay_plots(config, options)
 
     @staticmethod


### PR DESCRIPTION
## Summary
- clarify that `PlotService.overlay_plots` delegates to `report_builder.overlay_plots`

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69b3b8b8083239180399139647339