### PR TITLE
Document merge_pdfs inputs and output

### DIFF
--- a/m3c2/visualization/plot_service.py
+++ b/m3c2/visualization/plot_service.py
@@ -289,4 +289,14 @@ class PlotService:
 
     @staticmethod
     def merge_pdfs(pdf_paths: List[str], out_path: str) -> str:
+        """Merge several PDF files into a single document.
+
+        Args:
+            pdf_paths: List of paths to the PDF files to be merged. Nonexistent
+                files are skipped.
+            out_path: Destination path where the merged PDF will be stored.
+
+        Returns:
+            The path to the merged PDF file.
+        """
         return _merge_pdfs(pdf_paths, out_path)


### PR DESCRIPTION
## Summary
- clarify `merge_pdfs` by documenting expected PDF paths and output file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b69b3d9a748323af5403a6bdb5a023