### PR TITLE
docs: describe summary_pdf assembly

### DIFF
--- a/m3c2/visualization/report_builder.py
+++ b/m3c2/visualization/report_builder.py
@@ -282,6 +282,24 @@ def overlay_plots(config: PlotConfig, options: PlotOptions) -> None:
 
 
 def summary_pdf(config: PlotConfig) -> None:
+    """Assemble a PDF summary from previously generated plot PNGs.
+
+    Parameters
+    ----------
+    config : PlotConfig
+        Configuration describing where plot images are stored. The ``path``
+        attribute must point to a directory containing the PNG files and is
+        also used as the destination for the resulting PDF.
+
+    Produces
+    --------
+    A two-page document named ``ALLFOLDERS_comparison_report.pdf`` located in
+    ``config.path``. Each page arranges the PNG files
+    ``ALLFOLDERS_ALL_WITH_<suffix>.png`` and
+    ``ALLFOLDERS_ALL_INLIER_<suffix>.png`` for supported plot types (overlay
+    histograms, Gaussian and Weibull fits, box plots, Q-Q plots and grouped
+    bar charts) into a 2×3 grid.
+    """
     plot_types = [
         ("OverlayHistogramm", "Histogramm", (0, 0)),
         ("Boxplot", "Boxplot", (0, 1)),


### PR DESCRIPTION
## Summary
- Document how summary_pdf composes plot PNGs into a two-page PDF
- Clarify required PlotConfig path for locating images and saving the report

## Testing
- `python -m py_compile m3c2/visualization/report_builder.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*


------
https://chatgpt.com/codex/tasks/task_e_68b6c9835fa883239bec30a61b6dcbf5