### PR TITLE
Move visualization docstring before future imports

### DIFF
--- a/m3c2/visualization/visualization_service.py
+++ b/m3c2/visualization/visualization_service.py
@@ -1,6 +1,4 @@
 # visualization_service.py
-from __future__ import annotations
-
 """Utility helpers for visualising point cloud distance data.
 
 This module offers convenience functions for turning distance results into
@@ -8,6 +6,8 @@ plots or coloured PLY point clouds.  Optional dependencies such as
 ``seaborn`` or ``plyfile`` are imported lazily so that the module can be
 imported in environments where they are not installed.
 """
+
+from __future__ import annotations
 
 from typing import Optional, Tuple
 import numpy as np


### PR DESCRIPTION
## Summary
- ensure `visualization_service` module docstring precedes `from __future__ import annotations`

## Testing
- `PYTHONPATH=. pytest` *(fails: UnboundLocalError in test_run_single_propagates_unexpected, ValueError in test_run_m3c2_writes_outputs, TypeError in test_exclude_outliers)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c98546648323a911b7f6af993c2e