### PR TITLE
Move module docstring before future import

### DIFF
--- a/m3c2/io/format_handler.py
+++ b/m3c2/io/format_handler.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
 """File format handlers for point cloud data.
 
 This module provides reader functions for a variety of point cloud file
 formats, including ``XYZ``, ``LAS/LAZ``, ``PLY``, ``OBJ``, and ``GPC``.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 from importlib import import_module


### PR DESCRIPTION
## Summary
- place module docstring before future import in format_handler to satisfy Python conventions

## Testing
- `PYTHONPATH=. pytest` *(fails: UnboundLocalError, ValueError, TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c985df1883238bca2f541da5ab31