### PR TITLE
Refactor data loading modes and single-cloud handling

### DIFF
--- a/m3c2/pipeline/batch_orchestrator.py
+++ b/m3c2/pipeline/batch_orchestrator.py
@@ -128,7 +128,7 @@ class BatchOrchestrator:
         start = time.perf_counter()
 
         if cfg.stats_singleordistance == "distance":
-            ds, mov, ref, corepoints = self.data_loader.load_data(cfg, type="multicloud")
+            ds, mov, ref, corepoints = self.data_loader.load_data(cfg, mode="multicloud")
             out_base = ds.config.folder
 
         tag = self._run_tag(cfg)
@@ -185,7 +185,7 @@ class BatchOrchestrator:
 
         
         if cfg.stats_singleordistance == "single":
-            single_cloud = self.data_loader.load_data(cfg, type="singlecloud")
+            single_cloud = self.data_loader.load_data(cfg, mode="singlecloud")
 
             try:
                 logger.info("[Statistics] Berechne Statistiken …")

--- a/m3c2/pipeline/data_loader.py
+++ b/m3c2/pipeline/data_loader.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Tuple
 
 import numpy as np
 
@@ -17,7 +16,7 @@ logger = logging.getLogger(__name__)
 class DataLoader:
     """Load point cloud data and core points according to a configuration."""
 
-    def load_data(self, cfg, type) -> Tuple[DataSource, object, object, object]:
+    def load_data(self, cfg, mode: str) -> tuple[DataSource, object, object, object] | object:
         """Load point clouds and core points according to ``cfg``.
 
         Parameters
@@ -25,13 +24,18 @@ class DataLoader:
         cfg : PipelineConfig
             Configuration defining the location of the point clouds and
             which epoch to use for the core points.
+        mode : str
+            ``"multicloud"`` to load moving and reference epochs or
+            ``"singlecloud"`` to load a single epoch.
 
         Returns
         -------
-        tuple
-            ``(ds, mov, ref, corepoints)`` containing the :class:`DataSource`
-            used for loading, the moving and reference epochs and a NumPy array
-            of the core point coordinates.
+        tuple or object
+            For ``"multicloud"`` returns ``(ds, mov, ref, corepoints)``
+            containing the :class:`DataSource` used for loading, the moving
+            and reference epochs and a NumPy array of the core point
+            coordinates.  For ``"singlecloud"`` returns only the single cloud
+            epoch.
 
         Side Effects
         ------------
@@ -42,16 +46,16 @@ class DataLoader:
         -----
         This method is part of the public pipeline API.
         """
-        t0 = time.perf_counter()
-        
-        if type == "multicloud":
+        if mode == "multicloud":
             return self._load_data_multi(cfg)
 
-        if type == "singlecloud":
+        if mode == "singlecloud":
             return self._load_data_single(cfg)
 
+        raise ValueError(f"Unknown mode '{mode}'")
 
-    def _load_data_multi(self, cfg) -> Tuple[DataSource, object, object, object]:
+
+    def _load_data_multi(self, cfg) -> tuple[DataSource, object, object, object]:
         """Load multi-cloud data according to ``cfg``.
 
         Parameters
@@ -90,7 +94,7 @@ class DataLoader:
         )
         return ds, mov, ref, corepoints
 
-    def _load_data_single(self, cfg) -> Tuple[DataSource, object]:
+    def _load_data_single(self, cfg) -> object:
         """Load single-cloud data according to ``cfg``.
 
         Parameters
@@ -101,15 +105,14 @@ class DataLoader:
 
         Returns
         -------
-        tuple
-            ``(ds, single_cloud)`` containing the :class:`DataSource`
-            used for loading and the single cloud epoch.
+        object
+            The single cloud epoch.
         """
         t0 = time.perf_counter()
 
         ds_config = DataSourceConfig(
             os.path.join(cfg.data_dir, cfg.folder_id),
-            cfg.filename_singlecloud
+            cfg.filename_singlecloud,
         )
         ds_single = DataSource(ds_config)
 

--- a/tests/test_pipeline/test_batch_orchestrator.py
+++ b/tests/test_pipeline/test_batch_orchestrator.py
@@ -21,6 +21,7 @@ def test_load_data_uses_data_dir(tmp_path, monkeypatch):
         folder_id="sub",
         filename_mov="mov.xyz",
         filename_ref="ref.xyz",
+        filename_singlecloud="single.xyz",
         mov_as_corepoints=True,
         use_subsampled_corepoints=1,
         only_stats=False,
@@ -33,7 +34,7 @@ def test_load_data_uses_data_dir(tmp_path, monkeypatch):
         "m3c2.pipeline.data_loader.DataSource", DummyDS
     )
     loader = DataLoader()
-    ds, mov, ref, corepoints = loader.load_data(cfg)
+    ds, mov, ref, corepoints = loader.load_data(cfg, mode="multicloud")
 
     assert ds.config.folder == os.path.join(cfg.data_dir, cfg.folder_id)
     assert mov.shape == (1, 3)


### PR DESCRIPTION
## Summary
- rename DataLoader `type` argument to `mode`
- clarify that `_load_data_single` returns only the single epoch
- validate mode values and raise `ValueError` for unknown modes
- adjust BatchOrchestrator and tests for new API

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*
- `PYTHONPATH=. pytest tests/test_pipeline/test_batch_orchestrator.py::test_load_data_uses_data_dir -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6f00161d88323bc5153f94c767c21