### PR TITLE
Refine statistics runner responsibilities

### DIFF
--- a/m3c2/pipeline/batch_orchestrator.py
+++ b/m3c2/pipeline/batch_orchestrator.py
@@ -174,17 +174,16 @@ class BatchOrchestrator:
                 logger.exception("Unerwarteter Fehler beim Erzeugen von .ply Dateien für Ausreißer / Inlier")
                 raise
 
-        try:
-            logger.info("[Statistics] Berechne Statistiken …")
-            self.statistics_runner.compute_statistics(cfg, mov, ref, tag)
-        except (IOError, ValueError):
-            logger.exception("Fehler bei der Berechnung der Statistik")
-        except Exception:
-            logger.exception("Unerwarteter Fehler bei der Berechnung der Statistik")
-            raise
-
-        
-        if cfg.stats_singleordistance == "single":
+        if cfg.stats_singleordistance == "distance":
+            try:
+                logger.info("[Statistics] Berechne Statistiken …")
+                self.statistics_runner.compute_statistics(cfg, mov, ref, tag)
+            except (IOError, ValueError):
+                logger.exception("Fehler bei der Berechnung der Statistik")
+            except Exception:
+                logger.exception("Unerwarteter Fehler bei der Berechnung der Statistik")
+                raise
+        elif cfg.stats_singleordistance == "single":
             single_cloud = self.data_loader.load_data(cfg, type="singlecloud")
 
             try:

--- a/m3c2/pipeline/statistics_runner.py
+++ b/m3c2/pipeline/statistics_runner.py
@@ -24,7 +24,7 @@ class StatisticsRunner:
         self.output_format = output_format
 
     def compute_statistics(self, cfg, mov, ref, tag: str) -> None:
-        """Compute M3C2 statistics for a job.
+        """Compute distance based M3C2 statistics for a job.
 
         Parameters
         ----------
@@ -32,29 +32,26 @@ class StatisticsRunner:
             Configuration object describing the current job.  The runner
             expects attributes such as :attr:`stats_singleordistance`,
             :attr:`folder_id`, :attr:`project` and various filenames.
-        ref
-            Optional reference information.  The parameter is currently not
-            used but retained for API compatibility with other pipeline
+        mov, ref
+            Information on the moving and reference clouds.  The parameters are
+            currently unused but kept for API compatibility with other pipeline
             components.
         tag : str
             Identifier for the reference cloud when evaluating distance based
             statistics.
 
-        Branching
-        ---------
-        If ``cfg.stats_singleordistance`` is ``"distance"`` the method
-        computes statistics on the distances between two clouds using
-        :func:`StatisticsService.compute_m3c2_statistics`.  When the value is
-        ``"single"`` statistics for individual clouds are computed via
-        :func:`StatisticsService.calc_single_cloud_stats`.
+        Notes
+        -----
+        This method only handles ``"distance"`` statistics.  Computation of
+        statistics for individual clouds is handled separately via
+        :meth:`single_cloud_statistics_handler` and should be triggered by the
+        orchestrator.
 
         Output
         ------
-        Results are stored in ``outputs/{project}_output``.  Distance
-        statistics are written to ``{project}_m3c2_stats_distances`` and
-        single cloud statistics to ``{project}_m3c2_stats_clouds``.  The
-        extension is either ``.xlsx`` or ``.json`` depending on
-        ``self.output_format``.
+        Results are stored in ``outputs/{project}_output`` with the filename
+        ``{project}_m3c2_stats_distances`` and an extension of either
+        ``.xlsx`` or ``.json`` depending on ``self.output_format``.
 
         This method is part of the public pipeline API.
         """

--- a/tests/test_pipeline/test_batch_orchestrator_errors.py
+++ b/tests/test_pipeline/test_batch_orchestrator_errors.py
@@ -15,6 +15,7 @@ def _cfg(tmp_path, folder_id="run"):
         folder_id=folder_id,
         filename_mov="mov.xyz",
         filename_ref="ref.xyz",
+        filename_singlecloud="sc.xyz",
         mov_as_corepoints=True,
         use_subsampled_corepoints=1,
         only_stats=True,
@@ -63,15 +64,16 @@ def test_run_single_propagates_unexpected(monkeypatch, tmp_path):
     dummy_ds = SimpleNamespace(config=SimpleNamespace(folder=str(tmp_path)))
     arr = np.zeros((1, 3))
 
+    def fake_load_data(cfg, type="multicloud"):
+        if type == "singlecloud":
+            return arr
+        return (dummy_ds, arr, arr, arr)
+
+    monkeypatch.setattr(orchestrator.data_loader, "load_data", fake_load_data)
     monkeypatch.setattr(
-        orchestrator.data_loader, "load_data", lambda cfg: (dummy_ds, arr, arr, arr)
-    )
-    monkeypatch.setattr(
-        orchestrator.outlier_handler, "exclude_outliers", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("bad")))
-    monkeypatch.setattr(
-        orchestrator.visualization_runner,
-        "generate_clouds_outliers",
-        lambda *a, **k: None,
+        orchestrator.statistics_runner,
+        "single_cloud_statistics_handler",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("bad")),
     )
     monkeypatch.setattr(
         orchestrator.statistics_runner, "compute_statistics", lambda *a, **k: None

--- a/tests/test_pipeline/test_statistics_runner.py
+++ b/tests/test_pipeline/test_statistics_runner.py
@@ -31,13 +31,13 @@ def test_compute_statistics_distance(monkeypatch, caplog):
 
     runner = StatisticsRunner(output_format="excel")
     caplog.set_level(logging.INFO)
-    runner.compute_statistics(cfg, ref=None, tag="ref")
+    runner.compute_statistics(cfg, mov=None, ref=None, tag="ref")
 
     assert called["out_path"].endswith("proj_m3c2_stats_distances.xlsx")
     assert any("Stats on Distance" in rec.message for rec in caplog.records)
 
 
-def test_compute_statistics_single(monkeypatch, caplog):
+def test_single_cloud_statistics_handler(monkeypatch, caplog):
     called = {}
 
     def fake_calc_single_cloud_stats(**kwargs):
@@ -50,16 +50,14 @@ def test_compute_statistics_single(monkeypatch, caplog):
     )
 
     cfg = SimpleNamespace(
-        stats_singleordistance="single",
         folder_id="fid",
-        filename_mov="mov",
-        filename_ref="ref",
+        filename_singlecloud="cloud",
         project="proj",
     )
 
     runner = StatisticsRunner(output_format="json")
     caplog.set_level(logging.INFO)
-    runner.compute_statistics(cfg, ref=None, tag="ref")
+    runner.single_cloud_statistics_handler(cfg, singlecloud=None)
 
     assert called["out_path"].endswith("proj_m3c2_stats_clouds.json")
     assert any("Stats on SingleClouds" in rec.message for rec in caplog.records)
@@ -69,7 +67,7 @@ def test_invalid_output_format():
     runner = StatisticsRunner(output_format="xml")
     cfg = SimpleNamespace(stats_singleordistance="distance", folder_id="fid", filename_ref="ref")
     try:
-        runner.compute_statistics(cfg, ref=None, tag="ref")
+        runner.compute_statistics(cfg, mov=None, ref=None, tag="ref")
     except ValueError:
         pass
     else:


### PR DESCRIPTION
## Summary
- Clarify `StatisticsRunner.compute_statistics` to handle only distance-based statistics and document separate single-cloud handler
- Orchestrator now calls `single_cloud_statistics_handler` directly when requested
- Update tests for new statistics API

## Testing
- `pytest` *(fails: No module named 'm3c2')*
- `PYTHONPATH=$PWD pytest tests/test_pipeline/test_statistics_runner.py`
- `PYTHONPATH=$PWD:$PWD/m3c2 pytest tests/test_pipeline/test_batch_orchestrator_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6f00c8b148323af21df8600cb60a0