### PR TITLE
Refactor DataLoader parameter name

### DIFF
--- a/m3c2/pipeline/batch_orchestrator.py
+++ b/m3c2/pipeline/batch_orchestrator.py
@@ -128,7 +128,7 @@ class BatchOrchestrator:
         start = time.perf_counter()
 
         if cfg.stats_singleordistance == "distance":
-            ds, mov, ref, corepoints = self.data_loader.load_data(cfg, type="multicloud")
+            ds, mov, ref, corepoints = self.data_loader.load_data(cfg, mode="multicloud")
             out_base = ds.config.folder
 
         tag = self._run_tag(cfg)
@@ -185,7 +185,7 @@ class BatchOrchestrator:
 
         
         if cfg.stats_singleordistance == "single":
-            single_cloud = self.data_loader.load_data(cfg, type="singlecloud")
+            single_cloud = self.data_loader.load_data(cfg, mode="singlecloud")
 
             try:
                 logger.info("[Statistics] Berechne Statistiken …")

--- a/m3c2/pipeline/data_loader.py
+++ b/m3c2/pipeline/data_loader.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class DataLoader:
     """Load point cloud data and core points according to a configuration."""
 
-    def load_data(self, cfg, type) -> Tuple[DataSource, object, object, object]:
+    def load_data(self, cfg, mode) -> Tuple[DataSource, object, object, object]:
         """Load point clouds and core points according to ``cfg``.
 
         Parameters
@@ -25,6 +25,9 @@ class DataLoader:
         cfg : PipelineConfig
             Configuration defining the location of the point clouds and
             which epoch to use for the core points.
+        mode : str
+            ``"multicloud"`` to load moving and reference clouds or
+            ``"singlecloud"`` to load only a single epoch.
 
         Returns
         -------
@@ -43,11 +46,11 @@ class DataLoader:
         This method is part of the public pipeline API.
         """
         t0 = time.perf_counter()
-        
-        if type == "multicloud":
+
+        if mode == "multicloud":
             return self._load_data_multi(cfg)
 
-        if type == "singlecloud":
+        if mode == "singlecloud":
             return self._load_data_single(cfg)
 
 

--- a/tests/test_pipeline/test_batch_orchestrator.py
+++ b/tests/test_pipeline/test_batch_orchestrator.py
@@ -33,7 +33,7 @@ def test_load_data_uses_data_dir(tmp_path, monkeypatch):
         "m3c2.pipeline.data_loader.DataSource", DummyDS
     )
     loader = DataLoader()
-    ds, mov, ref, corepoints = loader.load_data(cfg)
+    ds, mov, ref, corepoints = loader.load_data(cfg, mode="multicloud")
 
     assert ds.config.folder == os.path.join(cfg.data_dir, cfg.folder_id)
     assert mov.shape == (1, 3)

--- a/tests/test_pipeline/test_batch_orchestrator_errors.py
+++ b/tests/test_pipeline/test_batch_orchestrator_errors.py
@@ -64,7 +64,7 @@ def test_run_single_propagates_unexpected(monkeypatch, tmp_path):
     arr = np.zeros((1, 3))
 
     monkeypatch.setattr(
-        orchestrator.data_loader, "load_data", lambda cfg: (dummy_ds, arr, arr, arr)
+        orchestrator.data_loader, "load_data", lambda cfg, mode: (dummy_ds, arr, arr, arr)
     )
     monkeypatch.setattr(
         orchestrator.outlier_handler, "exclude_outliers", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("bad")))


### PR DESCRIPTION
## Summary
- rename `type` parameter in `DataLoader.load_data` to `mode` and document options
- update orchestrator and tests to use the new `mode` argument

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'io.logging_utils')*


------
https://chatgpt.com/codex/tasks/task_e_68b6f020edfc832381333a574f7759f3