### PR TITLE
Add docstrings for CLI app tests

### DIFF
--- a/tests/test_cli/test_cli_app.py
+++ b/tests/test_cli/test_cli_app.py
@@ -1,3 +1,5 @@
+"""Tests for CLI application parser defaults and orchestration."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock
@@ -6,6 +8,12 @@ from m3c2.cli.cli import CLIApp
 
 
 def test_build_parser_defaults() -> None:
+    """Ensure parser is built with expected default values.
+
+    Returns
+    -------
+    None
+    """
     parser = CLIApp().build_parser()
     args = parser.parse_args([])
     assert args.data_dir == "data"
@@ -13,6 +21,19 @@ def test_build_parser_defaults() -> None:
 
 
 def test_run_invokes_orchestrator(monkeypatch, tmp_path) -> None:
+    """Validate that ``CLIApp.run`` invokes ``BatchOrchestrator``.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to patch the orchestrator class.
+    tmp_path : pathlib.Path
+        Temporary directory provided by pytest.
+
+    Returns
+    -------
+    None
+    """
     # create folder structure expected by CLIApp.run
     folder = tmp_path / "001"
     folder.mkdir()


### PR DESCRIPTION
## Summary
- document CLI app test module
- add NumPy-style docstrings for parser and orchestrator tests

## Testing
- `PYTHONPATH=. pytest tests/test_cli/test_cli_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b71338ac5883239e504f7039eb505b