### PR TITLE
Add NumPy-style docstrings to overlay plot tests

### DIFF
--- a/tests/test_visualization/test_overlay_plotter.py
+++ b/tests/test_visualization/test_overlay_plotter.py
@@ -1,3 +1,5 @@
+"""Tests for overlay plotting visualization utilities."""
+
 import numpy as np
 import matplotlib
 matplotlib.use("Agg")
@@ -13,6 +15,14 @@ from m3c2.visualization.overlay_plotter import (
 
 
 def test_get_common_range_empty():
+    """Verify handling of empty data in common range computation.
+
+    Returns
+    -------
+    None
+        The function asserts expected behavior and returns ``None``.
+    """
+
     data_min, data_max, x = get_common_range({})
     assert data_min == 0.0
     assert data_max == 1.0
@@ -20,6 +30,19 @@ def test_get_common_range_empty():
 
 
 def test_plot_functions_create_files(tmp_path):
+    """Ensure overlay plotting functions generate the correct files.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary directory provided by pytest.
+
+    Returns
+    -------
+    None
+        This function does not return a value.
+    """
+
     data = {
         "A": np.array([0.0, 1.0, 2.0]),
         "B": np.array([1.0, 2.0, 3.0]),
@@ -45,6 +68,19 @@ def test_plot_functions_create_files(tmp_path):
 
 
 def test_plot_overlay_boxplot_empty(tmp_path):
+    """Test plotting behavior when data input is empty.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary directory provided by pytest.
+
+    Returns
+    -------
+    None
+        The function verifies file creation without returning a value.
+    """
+
     # Should not raise and produce no file when data is empty
     plot_overlay_boxplot("f", "name", {}, {}, str(tmp_path))
     assert not (tmp_path / "f_name_Boxplot.png").exists()


### PR DESCRIPTION
## Summary
- add module docstring for overlay plotter test module
- document overlay plotter tests with NumPy-style docstrings

## Testing
- `PYTHONPATH=$PWD pytest tests/test_visualization/test_overlay_plotter.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7133572c48323b5dd88806bdbd49d