### PR TITLE
Add docstrings for comparison loader test

### DIFF
--- a/tests/test_visualization/test_comparison_loader.py
+++ b/tests/test_visualization/test_comparison_loader.py
@@ -1,8 +1,18 @@
+"""Tests for the comparison loader utilities."""
+
 import numpy as np
 from m3c2.visualization.comparison_loader import _load_and_mask
 
 
 def test_load_and_mask_removes_nan(tmp_path):
+    """Ensure NaN entries are removed by :func:`_load_and_mask`.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary directory provided by pytest.
+    """
+
     fid_dir = tmp_path / "fid1"
     fid_dir.mkdir()
     (fid_dir / "python_ref_m3c2_distances.txt").write_text("0.0\n1.0\nnan\n2.0\n")


### PR DESCRIPTION
## Summary
- add module-level docstring to comparison loader tests
- describe test ensuring NaN entries are removed with a NumPy-style docstring

## Testing
- `PYTHONPATH=. pytest tests/test_visualization/test_comparison_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68b71333a800832397d7f2782a1cdccd