### PR TITLE
Add docstrings for Bland-Altman plotter tests

### DIFF
--- a/tests/test_visualization/test_bland_altman_plotter.py
+++ b/tests/test_visualization/test_bland_altman_plotter.py
@@ -1,3 +1,9 @@
+"""Tests for the Bland–Altman plotter.
+
+These tests verify that the plotter creates output images when data is
+available and that it does not produce files for empty or missing inputs.
+"""
+
 import numpy as np
 import matplotlib
 matplotlib.use("Agg")
@@ -7,6 +13,16 @@ from m3c2.visualization.bland_altman_plotter import bland_altman_plot
 
 
 def test_bland_altman_plot_creates_file(tmp_path, monkeypatch):
+    """Ensure a Bland–Altman plot is written when data exists.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary directory for the output file.
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to replace the data loader.
+    """
+
     def fake_load(fid, refs):
         return np.array([1.0, 2.0, 3.0]), np.array([1.1, 2.1, 3.1])
 
@@ -17,6 +33,16 @@ def test_bland_altman_plot_creates_file(tmp_path, monkeypatch):
 
 
 def test_bland_altman_plot_handles_none(tmp_path, monkeypatch):
+    """Skip plotting when the loader yields ``None``.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary directory for the output file.
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to replace the data loader.
+    """
+
     def fake_load(fid, refs):
         return None
 
@@ -26,6 +52,16 @@ def test_bland_altman_plot_handles_none(tmp_path, monkeypatch):
 
 
 def test_bland_altman_plot_handles_empty_arrays(tmp_path, monkeypatch):
+    """Skip plotting when the loader returns empty arrays.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary directory for the output file.
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to replace the data loader.
+    """
+
     def fake_load(fid, refs):
         return np.array([]), np.array([])
 


### PR DESCRIPTION
## Summary
- Document Bland–Altman plotter tests and their fixtures
- Clarify behavior for missing or empty data in tests

## Testing
- `PYTHONPATH=. pytest tests/test_visualization/test_bland_altman_plotter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b713330a5c8323b5e22b47e0d3578c