### PR TITLE
docs: document m3c2 runner test

### DIFF
--- a/tests/test_orchestration/test_m3c2_runner.py
+++ b/tests/test_orchestration/test_m3c2_runner.py
@@ -1,6 +1,19 @@
+"""Tests for orchestration-level utilities for the M3C2 runner."""
+
 from orchestration.m3c2_runner import M3C2Runner
 from m3c2.core.m3c2_runner import M3C2Runner as CoreM3C2Runner
 
 
 def test_reexport_m3c2_runner():
+    """Verify that the orchestration runner re-exports the core implementation.
+
+    This test ensures that :class:`orchestration.m3c2_runner.M3C2Runner` is the
+    same class as :class:`m3c2.core.m3c2_runner.M3C2Runner`.
+
+    Returns
+    -------
+    None
+        This test does not return a value.
+    """
+
     assert M3C2Runner is CoreM3C2Runner


### PR DESCRIPTION
## Summary
- add module-level docstring for orchestration M3C2 runner tests
- document `test_reexport_m3c2_runner` with a NumPy-style docstring

## Testing
- `pytest tests/test_orchestration/test_m3c2_runner.py` *(fails: ModuleNotFoundError: No module named 'orchestration')*

------
https://chatgpt.com/codex/tasks/task_e_68b713310d448323a62f8f3c0a3eed1a