### PR TITLE
Add docstrings to M3C2 runner test

### DIFF
--- a/tests/test_core/test_m3c2_runner.py
+++ b/tests/test_core/test_m3c2_runner.py
@@ -1,3 +1,9 @@
+"""Tests for the :mod:`m3c2_runner` module.
+
+This module focuses on validating that the :class:`M3C2Runner` correctly
+interacts with the underlying ``py4dgeo`` library.
+"""
+
 import sys
 import types
 import importlib
@@ -5,6 +11,15 @@ import numpy as np
 
 
 def test_m3c2_runner(monkeypatch):
+    """Test the M3C2 runner with a dummy ``py4dgeo`` implementation.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to replace the ``py4dgeo`` module with a dummy
+        implementation.
+
+    """
     called = {}
 
     class DummyM3C2:


### PR DESCRIPTION
## Summary
- add module docstring for `test_m3c2_runner`
- provide NumPy-style docstring for the test function

## Testing
- `PYTHONPATH=/workspace/M3C2 pytest tests/test_core/test_m3c2_runner.py::test_m3c2_runner -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7132e16c48323bdadcae0944c1af9