### PR TITLE
Document I/O test subpackage

### DIFF
--- a/tests/test_io/__init__.py
+++ b/tests/test_io/__init__.py
@@ -1,0 +1,7 @@
+"""Test suite for input/output components.
+
+This subpackage covers reading and writing utilities such as data
+sources, format handlers, and filename services to ensure consistent I/O
+behavior across supported file formats.
+"""
+


### PR DESCRIPTION
## Summary
- add NumPy-style docstring for I/O test subpackage

## Testing
- `pytest tests/test_io -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b7131e13c88323987c29de50a0a9ac