### PR TITLE
Document Excel writer comment tests

### DIFF
--- a/tests/test_io/excel_writer/test_comments.py
+++ b/tests/test_io/excel_writer/test_comments.py
@@ -1,3 +1,5 @@
+"""Tests for Excel writer comment utilities."""
+
 import pytest
 from unittest.mock import patch, MagicMock
 from openpyxl import Workbook
@@ -13,6 +15,21 @@ from m3c2.io.excel_writer.comments_stats_distances import (
 
 
 def test_add_cloud_header_comments_sets_comments():
+    """Ensure timestamp comments are applied to the cloud stats sheet.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    >>> test_add_cloud_header_comments_sets_comments()
+    """
+
     wb = Workbook()
     ws = wb.active
     ws.title = "CloudStats"
@@ -31,6 +48,21 @@ def test_add_cloud_header_comments_sets_comments():
 
 
 def test_add_cloud_header_comments_missing_sheet():
+    """Raise an error when the cloud stats sheet is absent.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    >>> test_add_cloud_header_comments_missing_sheet()
+    """
+
     wb = Workbook()
     ws = wb.active
     ws.title = "Other"
@@ -44,6 +76,21 @@ def test_add_cloud_header_comments_missing_sheet():
 
 
 def test_add_header_comments_sets_comments():
+    """Ensure timestamp comments are applied to the distance results sheet.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    >>> test_add_header_comments_sets_comments()
+    """
+
     wb = Workbook()
     ws = wb.active
     ws.title = "Results"
@@ -62,6 +109,21 @@ def test_add_header_comments_sets_comments():
 
 
 def test_add_header_comments_missing_sheet():
+    """Raise an error when the distance results sheet is absent.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    >>> test_add_header_comments_missing_sheet()
+    """
+
     wb = Workbook()
     ws = wb.active
     ws.title = "Other"


### PR DESCRIPTION
## Summary
- add module-level docstring for Excel writer comment tests
- add detailed NumPy-style docstrings for comment writer test functions

## Testing
- `PYTHONPATH=. pytest tests/test_io/excel_writer/test_comments.py`

------
https://chatgpt.com/codex/tasks/task_e_68b71323422883239b97ba65eba42959