### PR TITLE
Add docstrings to delete filename tests

### DIFF
--- a/tests/test_io/filename_services/test_delete_filename.py
+++ b/tests/test_io/filename_services/test_delete_filename.py
@@ -1,3 +1,10 @@
+"""Tests for the :mod:`delete_filename` service.
+
+These tests ensure that file names prefixed with ``python_`` are correctly
+transformed or renamed and that the command-line interface respects the dry
+run option.
+"""
+
 import sys
 from pathlib import Path
 
@@ -18,10 +25,30 @@ from m3c2.io.filename_services import delete_filename
     ],
 )
 def test_transform(name, expected):
+    """Ensure the prefix ``python_`` is removed from file names.
+
+    Parameters
+    ----------
+    name : str
+        Original file name.
+    expected : str
+        Expected file name after transformation.
+    """
+
     assert delete_filename.transform(name) == expected
 
 
 def test_main_renames_and_dry_run(tmp_path, monkeypatch):
+    """Check recursive renaming and handling of the dry-run flag.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary directory used for creating test files.
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to modify :data:`sys.argv` for invoking the CLI.
+    """
+
     f1 = tmp_path / "python_file1.txt"
     f1.touch()
     sub = tmp_path / "sub"


### PR DESCRIPTION
## Summary
- document delete_filename test module
- add NumPy-style docstrings for transform and CLI dry-run tests

## Testing
- `pytest tests/test_io/filename_services/test_delete_filename.py`

------
https://chatgpt.com/codex/tasks/task_e_68b713211d5c8323bc11cd8566d1113f