### PR TITLE
Add docstring for filename service tests

### DIFF
--- a/tests/test_io/filename_services/__init__.py
+++ b/tests/test_io/filename_services/__init__.py
@@ -1,0 +1,5 @@
+"""Filename service tests.
+
+This package comprises tests for utilities that manipulate filenames,
+including operations for renaming and deleting files.
+"""


### PR DESCRIPTION
## Summary
- document filename service test package with NumPy-style module docstring

## Testing
- `pytest tests/test_io/filename_services -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71320830483238d9006aaeaac2236