### PR TITLE
docs: explain existing param handling

### DIFF
--- a/m3c2/pipeline/batch_orchestrator.py
+++ b/m3c2/pipeline/batch_orchestrator.py
@@ -235,6 +235,26 @@ class BatchOrchestrator:
 
 
     def _handle_existing_params(self, cfg: PipelineConfig, out_base: str, tag: str):
+        """Load previously determined M3C2 scale parameters.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration used to derive the expected parameter file name via
+            ``cfg.process_python_CC``.
+        out_base : str
+            Directory in which the parameter file is searched.
+        tag : str
+            Run identifier appended to the file name.
+
+        Returns
+        -------
+        Tuple[float, float]
+            ``(normal_scale, search_scale)`` read from
+            ``{out_base}/{cfg.process_python_CC}_{tag}_m3c2_params.txt`` if both
+            values are present.  Otherwise ``(numpy.nan, numpy.nan)`` is
+            returned.
+        """
 
         params_path = os.path.join(
             out_base, f"{cfg.process_python_CC}_{tag}_m3c2_params.txt"


### PR DESCRIPTION
## Summary
- document loading of previously computed M3C2 parameters

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b72fc1af8c8323a6152546849c80f3