### PR TITLE
docs: expand single-cloud processing docstring

### DIFF
--- a/m3c2/pipeline/batch_orchestrator.py
+++ b/m3c2/pipeline/batch_orchestrator.py
@@ -190,7 +190,29 @@ class BatchOrchestrator:
                 raise
 
     def _batch_process_singlecloud(self, cfg: PipelineConfig):
-        """Compute statistics for a single cloud."""
+        """Compute statistics for an individual point cloud.
+
+        Parameters
+        ----------
+        cfg : PipelineConfig
+            Configuration describing the input cloud and output settings.
+
+        Notes
+        -----
+        The cloud specified in ``cfg`` is loaded and the normal and
+        projection scales are determined using :attr:`scale_estimator`.
+        These scales are then passed to
+        ``statistics_runner.single_cloud_statistics_handler`` to compute
+        the statistical summaries written to the configured output paths.
+
+        Raises
+        ------
+        IOError, ValueError
+            If the input data is missing or the configuration is invalid.
+        Exception
+            Any unexpected error during scale estimation or statistics
+            computation is logged and re-raised.
+        """
 
         single_cloud = self.data_loader.load_data(cfg, mode="singlecloud")
 


### PR DESCRIPTION
## Summary
- clarify single-cloud statistics workflow in `_batch_process_singlecloud`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'io.logging_utils'; 'io' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b72fc784e4832396b43d669c25c358