### PR TITLE
Document multi-cloud statistics handler

### DIFF
--- a/m3c2/pipeline/statistics_runner.py
+++ b/m3c2/pipeline/statistics_runner.py
@@ -59,6 +59,30 @@ class StatisticsRunner:
             return self._multi_cloud_handler(cfg, mov, ref, tag)
 
     def _multi_cloud_handler(self, cfg, mov, ref, tag):
+        """Compute and export distance-based statistics across multiple clouds.
+
+        Parameters
+        ----------
+        cfg
+            Configuration object describing the current job. It provides the
+            output directory, project name and options for the statistics
+            calculation.
+        mov, ref
+            Information about the moving and reference clouds. The parameters
+            are currently unused but preserved for API compatibility with the
+            pipeline's public methods.
+        tag : str
+            Identifier for the reference cloud whose distance statistics are
+            calculated.
+
+        Side Effects
+        ------------
+        - Writes an ``.xlsx`` or ``.json`` file with distance statistics to
+          ``outputs/{project}_output`` depending on :attr:`output_format`.
+        - Logs progress information to the module logger.
+        - Delegates the heavy lifting to
+          :func:`m3c2.core.statistics.StatisticsService.compute_m3c2_statistics`.
+        """
         logger.info(
             f"[Stats on Distance] Berechne M3C2-Statistiken {cfg.folder_id},{cfg.filename_ref} …"
         )


### PR DESCRIPTION
## Summary
- Add detailed docstring for `_multi_cloud_handler` explaining purpose, parameters, and side effects in distance-based statistics.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2'; ModuleNotFoundError: No module named 'io.logging_utils')*

------
https://chatgpt.com/codex/tasks/task_e_68b72fc94ee4832392e308d4870b1b92