### PR TITLE
docs: expand docstring for comparedist plots

### DIFF
--- a/m3c2/cli/comparedist_plots.py
+++ b/m3c2/cli/comparedist_plots.py
@@ -25,7 +25,29 @@ def main(
     ref_variants: list[str] | None = None,
     outdir: str = "outputs",
 ) -> None:
-    """Configure and create distance comparison plots."""
+    """Configure and create distance comparison plots.
+
+    Parameters
+    ----------
+    folder_ids : list[str] | None, optional
+        Identifiers of point cloud folders to process. Defaults to
+        ``["0342-0349"]`` when ``None``.
+    ref_variants : list[str] | None, optional
+        Reference variants to compare. Defaults to ``["ref", "ref_ai"]`` when
+        ``None``.
+    outdir : str, optional
+        Target directory for generated plots. Defaults to ``"outputs"``.
+
+    Logging
+    -------
+    Configures logging via :func:`setup_logging` at a level resolved by
+    :func:`resolve_log_level`.
+
+    Side Effects
+    ------------
+    Creates statistical comparison plots and writes them to ``outdir`` while
+    emitting log messages.
+    """
 
     setup_logging(level=resolve_log_level())
 


### PR DESCRIPTION
## Summary
- detail optional parameters and logging in `comparedist_plots` CLI
- document side effects of plot generation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b72fd764f4832387d4279488909661