### PR TITLE
docs: expand LAS/LAZ reader docstring

### DIFF
--- a/m3c2/io/format_handler.py
+++ b/m3c2/io/format_handler.py
@@ -30,7 +30,23 @@ def read_xyz(path: Path) -> np.ndarray:
 
 
 def read_las(path: Path) -> np.ndarray:
-    """Read LAS/LAZ files using :mod:`laspy` lazily."""
+    """Read a ``.las`` or ``.laz`` file and return its point cloud.
+
+    LAS/LAZ reading requires the :mod:`laspy` package.  For compressed
+    ``.laz`` files the optional ``lazrs`` dependency of ``laspy`` must be
+    installed as well.
+
+    Parameters
+    ----------
+    path:
+        Path to the LAS/LAZ file to read.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(N, 3)`` containing the ``x``, ``y`` and ``z``
+        coordinates of the point cloud.
+    """
     logger.info("Reading LAS/LAZ file %s", path)
     try:
         laspy = import_module("laspy")


### PR DESCRIPTION
## Summary
- clarify LAS/LAZ reader requirements and outputs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b72fde5f8c8323996fad2de37a4d65