### PR TITLE
docs: expand GPC reader docstring

### DIFF
--- a/m3c2/io/format_handler.py
+++ b/m3c2/io/format_handler.py
@@ -101,7 +101,23 @@ def read_obj(path: Path) -> np.ndarray:
 
 
 def read_gpc(path: Path) -> np.ndarray:
-    """Read GPC files as plain text."""
+    """Read point coordinates from a GPC file.
+
+    The *GPC* (Geometrie-Punktwolke) format is a simple whitespace separated
+    text format where each line stores at least three floating point values:
+    ``x``, ``y`` and ``z``.  Additional columns are ignored.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Path to the ``.gpc`` file that should be read.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(N, 3)`` containing the point coordinates.
+    """
+
     logger.info("Reading GPC file %s", path)
     try:
         return np.loadtxt(path, dtype=np.float64, usecols=(0, 1, 2))


### PR DESCRIPTION
## Summary
- document GPC reader: describe text format, path argument, and array shape

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b72fe220688323bc7397c6ffc0bddd