### PR TITLE
docs: expand datasource configuration docstring

### DIFF
--- a/m3c2/config/datasource_config.py
+++ b/m3c2/config/datasource_config.py
@@ -24,7 +24,23 @@ from dataclasses import dataclass
 
 @dataclass
 class DataSourceConfig:
-    """Configuration for the data source."""
+    """Configuration for the data source.
+
+    Parameters
+    ----------
+    folder:
+        Directory containing the point cloud files.
+    mov_basename:
+        Basename for the moving point cloud file (without extension).
+    ref_basename:
+        Basename for the reference point cloud file (without extension).
+    filename_singlecloud:
+        Name used when a single point cloud file is provided.
+    mov_as_corepoints:
+        If ``True``, the moving cloud is used to derive core points.
+    use_subsampled_corepoints:
+        Factor by which to subsample the core points.
+    """
 
     folder: str
     mov_basename: str = "mov"


### PR DESCRIPTION
## Summary
- clarify DataSourceConfig attributes like folder, mov_basename and core point options

## Testing
- `PYTHONPATH=$PWD pytest` *(fails: ModuleNotFoundError: No module named 'io.logging_utils')*

------
https://chatgpt.com/codex/tasks/task_e_68b72fe3bbd08323a717dd4e3c5e2cd9