### PR TITLE
docs: expand outlier dataclass docstrings

### DIFF
--- a/m3c2/archive_moduls/exclude_outliers.py
+++ b/m3c2/archive_moduls/exclude_outliers.py
@@ -12,7 +12,20 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class OutlierConfig:
-    """Configuration for outlier detection."""
+    """Configuration for :class:`OutlierDetector`.
+
+    Parameters
+    ----------
+    dists_path : str
+        Path to a ``.txt`` file containing M3C2 distances with columns
+        ``x y z distance``.
+    method : str
+        Statistic used to derive the outlier threshold. Supported values are
+        ``"rmse"``, ``"iqr"``, ``"std"`` and ``"nmad"``.
+    outlier_multiplicator : float, optional
+        Multiplier applied to the chosen statistic to compute the final
+        threshold. Defaults to ``3.0``.
+    """
 
     dists_path: str
     method: str
@@ -21,7 +34,18 @@ class OutlierConfig:
 
 @dataclass
 class OutlierResult:
-    """Container holding split distance rows."""
+    """Result of an outlier detection run.
+
+    Attributes
+    ----------
+    inliers : :class:`numpy.ndarray`
+        Rows from the input distance file classified as inliers.
+    outliers : :class:`numpy.ndarray`
+        Rows from the input distance file classified as outliers.
+
+    Each array contains the four columns ``x``, ``y``, ``z`` and ``distance``
+    and can be written to disk using :meth:`OutlierDetector._save`.
+    """
 
     inliers: np.ndarray
     outliers: np.ndarray


### PR DESCRIPTION
## Summary
- detail fields and usage in `OutlierConfig`
- describe inlier/outlier arrays in `OutlierResult`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2', ModuleNotFoundError: No module named 'io.logging_utils'; 'io' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b72fe571b4832385b3cf2a2f8deeca