### PR TITLE
Improve JSON exporter error handling

### DIFF
--- a/m3c2/core/statistics/exporters.py
+++ b/m3c2/core/statistics/exporters.py
@@ -122,7 +122,8 @@ def _append_df_to_json(df_new: pd.DataFrame, out_json: str) -> None:
     if os.path.exists(out_json):
         try:
             df_old = pd.read_json(out_json)
-        except Exception:
+        except (OSError, ValueError, pd.errors.EmptyDataError) as exc:
+            logger.warning("Failed to read existing JSON '%s': %s", out_json, exc)
             df_old = pd.DataFrame(columns=["Timestamp"])
         cols = list(df_old.columns) if not df_old.empty else ["Timestamp"]
         if "Timestamp" not in cols:


### PR DESCRIPTION
## Summary
- handle specific JSON read exceptions in exporter
- log read errors and fall back to empty DataFrame
- test JSON exporter fallback behavior

## Testing
- `pytest tests/test_core/test_exporters.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7339fed3883239ac0b0fe6fd12e6b