### PR TITLE
Handle missing SciPy in convex hull calculation

### DIFF
--- a/m3c2/core/statistics/cloud_quality.py
+++ b/m3c2/core/statistics/cloud_quality.py
@@ -54,7 +54,8 @@ def _convex_hull_area_xy(xy: np.ndarray) -> float:
 
     try:
         from scipy.spatial import ConvexHull
-    except Exception:
+    except ImportError:
+        logger.warning("scipy is missing. Returning NaN for convex hull area.")
         return np.nan
     hull = ConvexHull(xy)
     return float(hull.volume)


### PR DESCRIPTION
## Summary
- Improve convex hull area helper by catching ImportError specifically
- Warn when SciPy is missing and return NaN for convex hull area

## Testing
- `pytest -q` *(fails: No module named 'm3c2'; No module named 'io.logging_utils')*

------
https://chatgpt.com/codex/tasks/task_e_68b733a23960832382933ab118b05669