### PR TITLE
Skip unreadable distance files when computing stats

### DIFF
--- a/m3c2/core/statistics/service.py
+++ b/m3c2/core/statistics/service.py
@@ -307,8 +307,17 @@ class StatisticsService:
             if os.path.exists(py_dist_path):
                 logger.info("Processing Python distances: %s", py_dist_path)
                 logger.info("Using Python params: %s", py_params_path)
-                
-                values = np.loadtxt(py_dist_path)
+                try:
+                    values = np.loadtxt(py_dist_path)
+                except (OSError, ValueError) as exc:
+                    logger.warning(
+                        "Skipping folder %s due to unreadable distances file %s: %s",
+                        fid,
+                        py_dist_path,
+                        exc,
+                    )
+                    continue
+
                 stats = cls.calc_stats(
                     values,
                     params_path=py_params_path if os.path.exists(py_params_path) else None,


### PR DESCRIPTION
## Summary
- Handle `np.loadtxt` failures when reading distance files
- Log and skip folders whose distance data can't be loaded

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'io.logging_utils'; 'io' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b733a2e168832395fc9dca987908be