### PR TITLE
Narrow exception handling in argparse GUI

### DIFF
--- a/m3c2/gui/argparse_gui.py
+++ b/m3c2/gui/argparse_gui.py
@@ -92,7 +92,7 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
             # argparse reports errors via SystemExit; show message instead
             messagebox.showerror("Ungültige Eingabe", "Bitte Eingaben prüfen.")
             return
-        except Exception as exc:
+        except (ValueError, OSError) as exc:
             logger.exception("Error parsing arguments")
             messagebox.showerror("Fehler", str(exc))
             return


### PR DESCRIPTION
## Summary
- limit arg parsing error handling to ValueError and OSError

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'io.logging_utils')*

------
https://chatgpt.com/codex/tasks/task_e_68b742a409e0832384a15090a7b86013