### PR TITLE
Handle main_func runtime errors specifically

### DIFF
--- a/m3c2/gui/argparse_gui.py
+++ b/m3c2/gui/argparse_gui.py
@@ -100,9 +100,12 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
         root.destroy()
         try:
             main_func(argv)
-        except Exception as exc:  # final safety net
+        except (RuntimeError, ValueError) as exc:
             logger.exception("Exception raised by main_func")
             messagebox.showerror("Fehler", str(exc))
+        except Exception:
+            logger.exception("Unexpected exception raised by main_func")
+            raise
 
     def on_cancel() -> None:
         """Close the GUI without executing the selected command."""


### PR DESCRIPTION
## Summary
- Avoid catching all exceptions around `main_func` in the argparse GUI
- Handle `RuntimeError` and `ValueError` with a message box
- Log and re-raise unexpected exceptions for easier debugging

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2'; ModuleNotFoundError: No module named 'io.logging_utils'; 'io' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b742a5d46c83238d92b22fdae25697