### PR TITLE
refactor: refine plot report exception handling

### DIFF
--- a/m3c2/cli/plot_report.py
+++ b/m3c2/cli/plot_report.py
@@ -62,8 +62,12 @@ def main(data_dir: str = DATA_DIR, out_dir: str = OUT_DIR) -> tuple[str, str]:
         logger.info("PDF (incl. outliers): %s", pdf_incl)
         logger.info("PDF (excl. outliers): %s", pdf_excl)
         return pdf_incl, pdf_excl
-    except Exception as exc:
+    except (OSError, RuntimeError) as exc:
         logger.error("Failed to generate summary PDFs: %s", exc, exc_info=True)
+    except Exception as exc:
+        logger.exception(
+            "Unexpected error during summary PDF generation: %s", exc
+        )
         raise
 
 


### PR DESCRIPTION
## Summary
- catch `OSError` and `RuntimeError` from `PlotService.build_parts_pdf`
- log unexpected exceptions during summary PDF generation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b742c794788323972d67f13d552beb