### PR TITLE
Limit stats exception handling

### DIFF
--- a/m3c2/cli/singlecloud_stats.py
+++ b/m3c2/cli/singlecloud_stats.py
@@ -59,8 +59,10 @@ def main(
             sheet_name=sheet_name,
             output_format=output_format,
         )
-    except Exception:
+    except (OSError, ValueError):
         logger.exception("Statistics computation failed")
+    except Exception:
+        logger.exception("Unexpected error during statistics computation")
         raise
     else:
         logger.info("Statistics computation completed successfully")


### PR DESCRIPTION
## Summary
- narrow single-cloud statistics CLI error handling to OSError and ValueError
- log unexpected errors before re-raising

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*


------
https://chatgpt.com/codex/tasks/task_e_68b742c61f288323a6cf09d72a072b06