### PR TITLE
Handle malformed distance files in outlier plots

### DIFF
--- a/m3c2/archive_moduls/outlier_plots.py
+++ b/m3c2/archive_moduls/outlier_plots.py
@@ -52,8 +52,8 @@ def main(
                     labels.append("All Distances")
                 else:
                     logger.warning("File %s has no valid data", file_path)
-        except Exception:
-            logger.warning("File %s is missing or unreadable", file_path)
+        except (OSError, ValueError) as exc:
+            logger.warning("File %s is missing or malformed: %s", file_path, exc)
 
         for suffix, label in inlier_suffixes:
             file_path = os.path.join(
@@ -68,8 +68,8 @@ def main(
                     labels.append(label)
                 else:
                     logger.warning("File %s is empty", file_path)
-            except Exception:
-                logger.warning("File %s is missing or unreadable", file_path)
+            except (OSError, ValueError) as exc:
+                logger.warning("File %s is missing or malformed: %s", file_path, exc)
 
         plt.figure(figsize=(8, 6))
         plt.boxplot(data_list, labels=labels)


### PR DESCRIPTION
## Summary
- narrow exception handling around `np.loadtxt` to catch OS and value errors
- log missing or malformed distance files without interrupting processing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2'; ModuleNotFoundError: No module named 'io.logging_utils')*

------
https://chatgpt.com/codex/tasks/task_e_68b742c45fe08323a89a9bde81532dd5