### PR TITLE
Log missing optional visualization dependencies

### DIFF
--- a/m3c2/visualization/visualization_service.py
+++ b/m3c2/visualization/visualization_service.py
@@ -22,15 +22,17 @@ logger = logging.getLogger(__name__)
 try:
     import seaborn as sns  # type: ignore
     _HAS_SNS = True
-except Exception:
+except ImportError:
     _HAS_SNS = False
+    logger.info("Missing optional dependency 'seaborn'.")
 
 # plyfile optional
 try:
     from plyfile import PlyData, PlyElement  # type: ignore
-except Exception:
+except ImportError:
     PlyData = None
     PlyElement = None
+    logger.info("Missing optional dependency 'plyfile'.")
 
 
 class VisualizationService:


### PR DESCRIPTION
## Summary
- Log missing seaborn and plyfile modules
- Replace broad exception handlers with ImportError

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'io.logging_utils'; 'io' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b742c0a88083238f39a8019866b089