### PR TITLE
Handle missing PyPDF2 gracefully

### DIFF
--- a/m3c2/visualization/report_builder.py
+++ b/m3c2/visualization/report_builder.py
@@ -460,8 +460,10 @@ def merge_pdfs(pdf_paths: List[str], out_path: str) -> str:
     """
     try:
         from PyPDF2 import PdfMerger
-    except Exception as e:
-        raise RuntimeError("PyPDF2 is required for merging PDFs") from e
+    except ImportError as e:
+        raise RuntimeError(
+            "PyPDF2 is required for merging PDFs but is not installed"
+        ) from e
 
     merger = PdfMerger()
     for p in pdf_paths:


### PR DESCRIPTION
## Summary
- Catch `ImportError` when importing `PyPDF2`'s `PdfMerger`
- Raise a clear `RuntimeError` when `PyPDF2` is absent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b742befb9c8323a4db8e8fcc749bdb