### PR TITLE
Refine comparison loader error handling

### DIFF
--- a/m3c2/visualization/comparison_loader.py
+++ b/m3c2/visualization/comparison_loader.py
@@ -72,8 +72,8 @@ def _load_ref_variant_data(fid: str, variant: str) -> np.ndarray | None:
         return None
     try:
         return np.loadtxt(path)
-    except Exception as e:  # pragma: no cover - logging only
-        logger.error("Failed to load %s: %s", path, e)
+    except (OSError, ValueError):  # pragma: no cover - logging only
+        logger.exception("Failed to load %s", path)
         return None
 
 


### PR DESCRIPTION
## Summary
- handle known OSError and ValueError cases when reading comparison data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*


------
https://chatgpt.com/codex/tasks/task_e_68b742bba54083238e7016ff05927715