### PR TITLE
Handle specific errors when reading GPC files

### DIFF
--- a/m3c2/io/format_handler.py
+++ b/m3c2/io/format_handler.py
@@ -173,7 +173,7 @@ def read_gpc(path: Path) -> np.ndarray:
     logger.info("Reading GPC file %s", path)
     try:
         return np.loadtxt(path, dtype=np.float64, usecols=(0, 1, 2))
-    except Exception:
+    except (OSError, ValueError):
         logger.exception("Failed to read GPC file %s", path)
         raise
 


### PR DESCRIPTION
## Summary
- Catch `OSError` and `ValueError` when reading GPC files instead of a blanket `Exception`
- Log errors and rethrow to preserve stack traces

## Testing
- `pytest tests/test_io -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'io.logging_utils')*


------
https://chatgpt.com/codex/tasks/task_e_68b742b2ca6083239a201a0221677bf0