### PR TITLE
Improve LAS reader error handling

### DIFF
--- a/m3c2/io/format_handler.py
+++ b/m3c2/io/format_handler.py
@@ -68,7 +68,7 @@ def read_las(path: Path) -> np.ndarray:
     logger.info("Reading LAS/LAZ file %s", path)
     try:
         laspy = import_module("laspy")
-    except Exception as exc:  # pragma: no cover - dependency issue
+    except ImportError as exc:  # pragma: no cover - dependency issue
         logger.exception("LAS/LAZ found, but 'laspy' is not installed.")
         raise RuntimeError("LAS/LAZ found, but 'laspy' is not installed.") from exc
 
@@ -79,7 +79,7 @@ def read_las(path: Path) -> np.ndarray:
         raise RuntimeError(
             "LAZ detected, please install 'laspy[lazrs]'.",
         ) from exc
-    except Exception:
+    except (laspy.LaspyException, OSError):
         logger.exception("Failed to read LAS/LAZ file %s", path)
         raise
     return np.vstack([las.x, las.y, las.z]).T.astype(np.float64)


### PR DESCRIPTION
## Summary
- enhance LAS/LAZ reader to catch missing `laspy`
- handle `laspy.LaspyException` and `OSError` separately when reading

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'm3c2')*
- `PYTHONPATH=. pytest tests/test_io/test_format_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_68b742ae258c8323ae111f12edf405ca