### PR TITLE
Narrow outlier handler exceptions

### DIFF
--- a/m3c2/archive_moduls/outlier_handler.py
+++ b/m3c2/archive_moduls/outlier_handler.py
@@ -65,7 +65,7 @@ class OutlierHandler:
                 outlier_multiplicator=outlier_multiplicator,
             )
             logger.info("[Outlier] Entfernen abgeschlossen")
-        except Exception:
-            # Surface errors to callers while logging the stack trace
-            logger.exception("[Outlier] Fehler beim Entfernen der Ausreißer")
+        except (OSError, ValueError) as err:
+            # Surface specific errors to callers while logging the stack trace
+            logger.exception("[Outlier] Fehler beim Entfernen der Ausreißer: %s", err)
             raise


### PR DESCRIPTION
## Summary
- Restrict outlier removal error handling to `OSError` and `ValueError`
- Log specific failure details before re-raising

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'io.logging_utils')*

------
https://chatgpt.com/codex/tasks/task_e_68b742c2c6808323a9378f486c4f6ef0