### PR TITLE
Refine Weibull fit error handling

### DIFF
--- a/m3c2/visualization/overlay_plotter.py
+++ b/m3c2/visualization/overlay_plotter.py
@@ -170,8 +170,14 @@ def plot_overlay_weibull(
         try:
             a, loc, b = weibull_min.fit(arr)
             weibull_params[v] = (float(a), float(loc), float(b))
-        except Exception as e:
-            logger.warning("[Report] Weibull-Fit fehlgeschlagen (%s/%s, %s): %s", fid, fname, v, e)
+        except (ValueError, RuntimeError):
+            logger.warning(
+                "[Report] Weibull-Fit fehlgeschlagen (%s/%s, %s) mit Daten: %s",
+                fid,
+                fname,
+                v,
+                arr,
+            )
 
     plt.figure(figsize=(10, 6))
     labels = labels_order or list(weibull_params.keys())


### PR DESCRIPTION
## Summary
- Narrow Weibull fitting error handling to ValueError and RuntimeError
- Include dataset details in Weibull fit warnings

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'io.logging_utils')*


------
https://chatgpt.com/codex/tasks/task_e_68b742b82460832395fc4c089878646c