### PR TITLE
Limit OBJ reader error handling to OS and value errors

### DIFF
--- a/m3c2/io/format_handler.py
+++ b/m3c2/io/format_handler.py
@@ -146,8 +146,8 @@ def read_obj(path: Path) -> np.ndarray:
                             path,
                             line,
                         )
-    except Exception:
-        logger.exception("Failed to read OBJ file %s", path)
+    except (OSError, ValueError) as exc:
+        logger.exception("Failed to read OBJ file %s: %s", path, exc)
         raise
     return np.asarray(vertices, dtype=np.float64)
 


### PR DESCRIPTION
## Summary
- narrow OBJ reader exception handling to `OSError` and `ValueError`
- log underlying error details and re-raise

## Testing
- `PYTHONPATH=. pytest tests/test_io/test_format_handler.py::test_read_obj -q`
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'io.logging_utils'; 'io' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b742afd4c48323bbc7a83a4280c502