### PR TITLE
Handle XYZ read errors specifically

### DIFF
--- a/m3c2/io/format_handler.py
+++ b/m3c2/io/format_handler.py
@@ -29,9 +29,11 @@ def read_xyz(path: Path) -> np.ndarray:
 
     Raises
     ------
-    Exception
-        Any error encountered while reading the file is logged and
-        re-raised.
+    OSError
+        If the file cannot be accessed. The error is logged and re-raised.
+    ValueError
+        If the file contents cannot be parsed into ``float`` values.
+        The error is logged and re-raised.
 
     Returns
     -------
@@ -42,7 +44,7 @@ def read_xyz(path: Path) -> np.ndarray:
     logger.info("Reading XYZ file %s", path)
     try:
         return np.loadtxt(path, dtype=np.float64, usecols=(0, 1, 2))
-    except Exception:
+    except (OSError, ValueError):
         logger.exception("Failed to read XYZ file %s", path)
         raise
 


### PR DESCRIPTION
## Summary
- tighten exception handling in `read_xyz` to only catch `OSError` and `ValueError`
- log file read failures and re-raise

## Testing
- `PYTHONPATH=/workspace/M3C2 pytest` *(fails: ModuleNotFoundError: No module named 'io.logging_utils')*
- `PYTHONPATH=/workspace/M3C2 pytest tests/test_io/test_format_handler.py::test_read_xyz -q`


------
https://chatgpt.com/codex/tasks/task_e_68b742acdc6083238b4c63fafb6ebbb2