### PR TITLE
Handle seaborn TypeError to restore box plot fallback

### DIFF
--- a/m3c2/visualization/overlay_plotter.py
+++ b/m3c2/visualization/overlay_plotter.py
@@ -225,14 +225,28 @@ def plot_overlay_boxplot(
         order = labels_order or list(df["Version"].unique())
         palette = {v: colors.get(v) for v in order}
         plt.figure(figsize=(10, 6))
-        sns.boxplot(data=df, x="Version", y="Distanz", palette=palette, legend=False, order=order)
+        sns.boxplot(
+            data=df,
+            x="Version",
+            y="Distanz",
+            palette=palette,
+            legend=False,
+            order=order,
+        )
         plt.title(title_text or f"Boxplot – {fid}/{fname}")
         plt.xlabel("Version")
         plt.ylabel("M3C2 distance")
         plt.tight_layout()
         plt.savefig(os.path.join(outdir, f"{fid}_{fname}_Boxplot.png"))
         plt.close()
-    except ImportError:
+    except (ImportError, TypeError) as e:
+        if isinstance(e, TypeError):
+            logger.debug(
+                "[Report] seaborn.boxplot failed (%s/%s): %s; falling back to matplotlib",
+                fid,
+                fname,
+                e,
+            )
         labels = labels_order or list(data.keys())
         arrs = [data[v] for v in labels]
         plt.figure(figsize=(10, 6))


### PR DESCRIPTION
## Summary
- Catch `TypeError` from `seaborn.boxplot` and fall back to matplotlib
- Log seaborn boxplot failures for easier debugging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'm3c2')*

------
https://chatgpt.com/codex/tasks/task_e_68b749ac0d088323ab12576205b96049