### PR TITLE
Handle orchestrator failures in CLI

### DIFF
--- a/m3c2/cli/cli.py
+++ b/m3c2/cli/cli.py
@@ -267,7 +267,7 @@ class CLIApp:
 
         try:
             orchestrator.run_all()
-        except RuntimeError as e:
+        except Exception as e:
             self.logger.error("Error occurred while running orchestrator: %s", e)
             return 1
 

--- a/tests/test_cli/test_cli_app.py
+++ b/tests/test_cli/test_cli_app.py
@@ -59,14 +59,14 @@ def test_run_invokes_orchestrator(monkeypatch, tmp_path) -> None:
     orchestrator_instance.run_all.assert_called_once_with()
 
 
-def test_run_handles_runtime_error(monkeypatch, tmp_path) -> None:
+def test_run_handles_run_all_exception(monkeypatch, tmp_path) -> None:
     """``CLIApp.run`` returns a non-zero status on orchestrator failure."""
 
     folder = tmp_path / "001"
     folder.mkdir()
 
     orchestrator_cls = MagicMock()
-    orchestrator_cls.return_value.run_all.side_effect = RuntimeError("boom")
+    orchestrator_cls.return_value.run_all.side_effect = Exception("boom")
     monkeypatch.setattr("m3c2.cli.cli.BatchOrchestrator", orchestrator_cls)
 
     app = CLIApp()


### PR DESCRIPTION
## Summary
- Catch any exception from `BatchOrchestrator.run_all` so CLI logs and returns a non-zero status
- Update CLI test to simulate general orchestrator exceptions

## Testing
- `PYTHONPATH=$PWD pytest tests/test_cli/test_cli_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7494f17308323993e921943ca1bfd