### PR TITLE
Transpose single cloud stats Excel export

### DIFF
--- a/m3c2/core/statistics/exporters.py
+++ b/m3c2/core/statistics/exporters.py
@@ -207,32 +207,58 @@ def write_cloud_stats(
     if df.empty:
         logger.info("Skipping writing cloud stats to %s - no data", out_path)
         return
-    ts = _now_timestamp()
-    df.insert(0, "Timestamp", ts)
-    if os.path.exists(out_path):
-        try:
-            if output_format.lower() == "json":
-                old = pd.read_json(out_path)
-            else:
-                old = pd.read_excel(out_path, sheet_name=sheet_name)
-        except (OSError, ValueError, pd.errors.EmptyDataError):
-            logger.exception(
-                "Failed to read existing cloud stats from %s; creating empty table",
-                out_path,
-            )
-            old = pd.DataFrame(columns=["Timestamp"])
-        cols = list(old.columns) if not old.empty else ["Timestamp"]
-        for c in df.columns:
-            if c not in cols:
-                cols.append(c)
-        old = old.reindex(columns=cols)
-        df = df.reindex(columns=cols)
-        all_df = pd.concat([old, df], ignore_index=True)
-    else:
-        all_df = df
 
     if output_format.lower() == "json":
+        ts = _now_timestamp()
+        df.insert(0, "Timestamp", ts)
+        if os.path.exists(out_path):
+            try:
+                old = pd.read_json(out_path)
+            except (OSError, ValueError, pd.errors.EmptyDataError):
+                logger.exception(
+                    "Failed to read existing cloud stats from %s; creating empty table",
+                    out_path,
+                )
+                old = pd.DataFrame(columns=["Timestamp"])
+            cols = list(old.columns) if not old.empty else ["Timestamp"]
+            for c in df.columns:
+                if c not in cols:
+                    cols.append(c)
+            old = old.reindex(columns=cols)
+            df = df.reindex(columns=cols)
+            all_df = pd.concat([old, df], ignore_index=True)
+        else:
+            all_df = df
+        out_dir = os.path.dirname(out_path)
+        if out_dir:
+            os.makedirs(out_dir, exist_ok=True)
         all_df.to_json(out_path, orient="records", indent=2)
     else:
+        ts = _now_timestamp()
+        run_labels: List[str] = []
+        for i, row in df.iterrows():
+            folder = row.get("Folder", f"run{i}")
+            run_labels.append(f"{folder}_{ts}")
+        df.insert(0, "Run", run_labels)
+        df = df.set_index("Run")
+        if "Folder" in df.columns:
+            df = df.drop(columns=["Folder"])
+        df_t = df.T
+        df_t.index.name = "Metric"
+        out_dir = os.path.dirname(out_path)
+        if out_dir:
+            os.makedirs(out_dir, exist_ok=True)
+        if os.path.exists(out_path):
+            try:
+                old = pd.read_excel(out_path, sheet_name=sheet_name, index_col=0)
+            except (OSError, ValueError, pd.errors.EmptyDataError):
+                logger.exception(
+                    "Failed to read existing cloud stats from %s; creating empty table",
+                    out_path,
+                )
+                old = pd.DataFrame()
+            all_df = old.join(df_t, how="outer")
+        else:
+            all_df = df_t
         with pd.ExcelWriter(out_path, engine="openpyxl", mode="w") as w:
-            all_df.to_excel(w, index=False, sheet_name=sheet_name)
+            all_df.to_excel(w, sheet_name=sheet_name)

--- a/m3c2/core/statistics/service.py
+++ b/m3c2/core/statistics/service.py
@@ -427,6 +427,8 @@ class StatisticsService:
             rows.append(stats)
 
         df_result = pd.DataFrame(rows)
+        df_result_t = df_result.set_index("Folder").T
+        df_result_t.index.name = "Metric"
         if out_path and rows:
             write_cloud_stats(
                 rows,
@@ -434,7 +436,7 @@ class StatisticsService:
                 sheet_name=sheet_name,
                 output_format=output_format,
             )
-        return df_result
+        return df_result_t
 
     @staticmethod
     def _load_params(params_path: Optional[str]) -> Tuple[float, float]:


### PR DESCRIPTION
## Summary
- flip single cloud stats Excel layout to show metrics in rows and runs as columns
- return transposed DataFrame from `calc_single_cloud_stats`
- adjust tests for new exporter orientation

## Testing
- `pytest tests/test_core/test_exporters.py::test_write_cloud_stats_excel -q`
- `pytest -q` *(fails: No module named 'm3c2' and 'io.logging_utils')*


------
https://chatgpt.com/codex/tasks/task_e_68b7dbada4948323a1eb794ddbde1cd9