### PR TITLE
Ensure metadata columns lead cloud stats export

### DIFF
--- a/m3c2/cli/plot_report.py
+++ b/m3c2/cli/plot_report.py
@@ -14,9 +14,9 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
-from visualization.plot_service import PlotService
-from io.logging_utils import resolve_log_level, setup_logging
-from config.plot_config import PlotOptions
+from m3c2.visualization.plot_service import PlotService
+from m3c2.io.logging_utils import resolve_log_level, setup_logging
+from m3c2.config.plot_config import PlotOptions
 
 # Input and output directories for the TUNSPEKT Labordaten_all dataset.
 DATA_DIR = os.path.join(ROOT, "data", "TUNSPEKT Labordaten_all")

--- a/m3c2/core/statistics/service.py
+++ b/m3c2/core/statistics/service.py
@@ -355,6 +355,7 @@ class StatisticsService:
 
         filename_singlecloud: str,
         singlecloud: Optional[object] = None,
+        data_dir: str = "",
 
         area_m2: Optional[float] = None,
         radius: float = None,
@@ -411,6 +412,8 @@ class StatisticsService:
         """
         rows: List[Dict] = []
 
+        from datetime import datetime
+
         for fid in folder_ids:
 
             pts = singlecloud.cloud if hasattr(singlecloud, "cloud") else singlecloud
@@ -423,16 +426,19 @@ class StatisticsService:
                 sample_size=sample_size,
                 use_convex_hull=use_convex_hull,
             )
-            # Ensure "File" and "Folder" appear first in the resulting row
+            ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             stats = {
-                "File": filename_singlecloud,
+                "Timestamp": ts,
+                "Data Dir": data_dir,
                 "Folder": fid,
+                "File": filename_singlecloud,
                 **stats,
             }
             rows.append(stats)
 
         df_result = pd.DataFrame(rows)
-        df_result_t = df_result.set_index("Folder").T
+        df_result_t = df_result.T
+        df_result_t.columns = df_result.get("Folder", pd.Series(range(len(df_result)))).tolist()
         df_result_t.index.name = "Metric"
         if out_path and rows:
             write_cloud_stats(

--- a/m3c2/pipeline/statistics_runner.py
+++ b/m3c2/pipeline/statistics_runner.py
@@ -142,6 +142,7 @@ class StatisticsRunner:
             folder_ids=[cfg.folder_id],
             filename_singlecloud=cfg.filename_singlecloud,
             singlecloud=singlecloud,
+            data_dir=cfg.data_dir,
             radius=normal,
             out_path=out_path,
             sheet_name="CloudStats",

--- a/tests/test_core/test_exclude_outliers.py
+++ b/tests/test_core/test_exclude_outliers.py
@@ -95,7 +95,7 @@ def test_outlier_detector_class(tmp_path):
     _write_distances(file_path)
 
     config = OutlierConfig(
-        file_path=str(file_path), method="rmse", outlier_multiplicator=1.0
+        dists_path=str(file_path), method="rmse", outlier_multiplicator=1.0
     )
     detector = OutlierDetector(config)
     res = detector.run()

--- a/tests/test_core/test_exporters.py
+++ b/tests/test_core/test_exporters.py
@@ -78,31 +78,29 @@ def test_append_df_to_json_handles_read_errors(tmp_path, caplog):
 
 
 def test_write_cloud_stats_excel():
-    """Ensure ``write_cloud_stats`` writes runs as columns in Excel by default.
+    """Ensure ``write_cloud_stats`` writes metrics as rows with metadata first."""
 
-    Notes
-    -----
-    The DataFrame passed to ``to_excel`` should have metrics as rows and
-    run identifiers as columns.
-    """
-
-    rows = [{"Folder": "run1", "a": 1}]
+    rows = [{
+        "Timestamp": "ts",
+        "Data Dir": "dd",
+        "Folder": "run1",
+        "File": "f",
+        "a": 1,
+    }]
     captured = {}
 
     def fake_to_excel(self, *args, **kwargs):
         captured["df"] = self
 
     with patch("os.path.exists", return_value=False), \
-         patch("m3c2.core.statistics.exporters._now_timestamp", return_value="ts"), \
          patch("m3c2.core.statistics.exporters.pd.ExcelWriter") as m_writer, \
          patch("pandas.DataFrame.to_excel", new=fake_to_excel):
         m_writer.return_value.__enter__.return_value = MagicMock()
         exporters.write_cloud_stats(rows, out_path="dummy.xlsx")
 
     df_written = captured["df"]
-    assert "Metric" == df_written.index.name
-    assert "a" in df_written.index
-    assert "run1_ts" in df_written.columns
+    assert list(df_written.index) == ["Timestamp", "Data Dir", "Folder", "File", "a"]
+    assert list(df_written.columns) == ["run1_ts"]
 
 
 def test_write_cloud_stats_json():

--- a/tests/test_core/test_statistics_service_singlecloud.py
+++ b/tests/test_core/test_statistics_service_singlecloud.py
@@ -9,8 +9,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from m3c2.core.statistics import service
 
 
-def test_calc_single_cloud_stats_file_folder_first(monkeypatch):
-    """Ensure resulting rows start with File and Folder keys."""
+def test_calc_single_cloud_stats_metadata_first(monkeypatch):
+    """Ensure resulting rows start with metadata keys."""
 
     def fake_calc_single_cloud_stats(
         pts,
@@ -34,10 +34,16 @@ def test_calc_single_cloud_stats_file_folder_first(monkeypatch):
         folder_ids=["fid"],
         filename_singlecloud="file",
         singlecloud=None,
+        data_dir="dd",
         out_path="out.json",
         output_format="json",
     )
 
     assert captured_rows, "No rows were captured"
-    assert list(captured_rows[0].keys())[:2] == ["File", "Folder"]
+    assert list(captured_rows[0].keys())[:4] == [
+        "Timestamp",
+        "Data Dir",
+        "Folder",
+        "File",
+    ]
 

--- a/tests/test_pipeline/test_statistics_runner.py
+++ b/tests/test_pipeline/test_statistics_runner.py
@@ -89,11 +89,12 @@ def test_single_cloud_statistics_handler(monkeypatch, caplog):
         folder_id="fid",
         filename_singlecloud="cloud",
         project="proj",
+        data_dir="dd",
     )
 
     runner = StatisticsRunner(output_format="json")
     caplog.set_level(logging.INFO)
-    runner.single_cloud_statistics_handler(cfg, singlecloud=None)
+    runner.single_cloud_statistics_handler(cfg, singlecloud=None, normal=1.0)
 
     assert called["out_path"].endswith("proj_m3c2_stats_clouds.json")
     assert any("Stats on SingleClouds" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- transpose per-cloud statistics so each run becomes a column and metrics (including Timestamp, Data Dir, Folder and File) appear as rows
- include folder names when transposing single-cloud results returned by the service

## Testing
- `PYTHONPATH=. pytest tests/test_core/test_statistics_service_singlecloud.py tests/test_core/test_exporters.py tests/test_pipeline/test_statistics_runner.py tests/test_core/test_exclude_outliers.py`
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError in pipeline outlier handler; unexpected errors in batch orchestrator tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ed050fb4832388faf82a779958bf