### PR TITLE
Append cloud stats via concat to allow duplicate columns

### DIFF
--- a/m3c2/core/statistics/exporters.py
+++ b/m3c2/core/statistics/exporters.py
@@ -211,7 +211,10 @@ def write_cloud_stats(
                         out_path,
                     )
                     old = pd.DataFrame()
-                all_df = old.join(df, how="outer")
+                # Simply append new run columns without checking for
+                # duplicate column names. ``pd.concat`` allows duplicate
+                # columns and will align rows on the index.
+                all_df = pd.concat([old, df], axis=1)
             else:
                 all_df = df
             out_dir = os.path.dirname(out_path)
@@ -231,7 +234,10 @@ def write_cloud_stats(
                         out_path,
                     )
                     old = pd.DataFrame()
-                all_df = old.join(df, how="outer")
+                # Append new runs even if column names already exist.
+                # ``pd.concat`` handles duplicate columns by keeping them
+                # separate and aligning on the index.
+                all_df = pd.concat([old, df], axis=1)
             else:
                 all_df = df
             with pd.ExcelWriter(out_path, engine="openpyxl", mode="w") as w:


### PR DESCRIPTION
## Summary
- use `pd.concat` when appending per-cloud stats so duplicate column names are allowed

## Testing
- `PYTHONPATH=. pytest -q` *(fails: TypeError: setup_logging() got an unexpected keyword argument 'level')*

------
https://chatgpt.com/codex/tasks/task_e_68b800cdd04c8323bfc586aaf62f95bb