### PR TITLE
Refactor tests and logging

### DIFF
--- a/m3c2/archive_moduls/outlier_plots.py
+++ b/m3c2/archive_moduls/outlier_plots.py
@@ -20,7 +20,9 @@ def main(
 ) -> None:
     """Create boxplots comparing full and inlier-filtered distances."""
 
-    setup_logging(level=os.getenv("LOG_LEVEL", "INFO"))
+    # Logging configuration relies on environment variables or configuration
+    # files; no explicit level argument is necessary.
+    setup_logging()
 
     variants = variants or [
         ("ref", "python_ref_m3c2_distances.txt"),

--- a/m3c2/cli/comparedist_plots.py
+++ b/m3c2/cli/comparedist_plots.py
@@ -8,7 +8,7 @@ import logging
 import sys
 import os
 
-from m3c2.io.logging_utils import resolve_log_level, setup_logging
+from m3c2.io.logging_utils import setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,9 @@ def main(
     emitting log messages.
     """
 
-    setup_logging(level=resolve_log_level())
+    # ``setup_logging`` reads the desired log level from configuration and the
+    # environment, so no explicit level argument is required here.
+    setup_logging()
 
     folder_ids = folder_ids or ["0342-0349"]
     ref_variants = ref_variants or ["ref", "ref_ai"]

--- a/m3c2/cli/plot_report.py
+++ b/m3c2/cli/plot_report.py
@@ -15,7 +15,7 @@ if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
 from m3c2.visualization.plot_service import PlotService
-from m3c2.io.logging_utils import resolve_log_level, setup_logging
+from m3c2.io.logging_utils import setup_logging
 from m3c2.config.plot_config import PlotOptions
 
 # Input and output directories for the TUNSPEKT Labordaten_all dataset.
@@ -26,7 +26,8 @@ OUT_DIR = os.path.join(ROOT, "outputs", "TUNSPEKT Labordaten_all", "plots")
 def main(data_dir: str = DATA_DIR, out_dir: str = OUT_DIR) -> tuple[str, str]:
     """Generate summary PDF reports for already generated plots."""
 
-    setup_logging(level=resolve_log_level())
+    # Configure logging using defaults from configuration/environment.
+    setup_logging()
     logger.info("Generating summary PDF reports from %s to %s", data_dir, out_dir)
 
     # Example configuration for generating additional grouped plots.

--- a/m3c2/cli/singlecloud_stats.py
+++ b/m3c2/cli/singlecloud_stats.py
@@ -3,7 +3,7 @@
 import logging
 
 from m3c2.core.statistics import StatisticsService
-from m3c2.io.logging_utils import resolve_log_level, setup_logging
+from m3c2.io.logging_utils import setup_logging
 
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,8 @@ def main(
 ) -> None:
     """Invoke :func:`StatisticsService.calc_single_cloud_stats` with defaults."""
 
-    setup_logging(level=resolve_log_level())
+    # ``setup_logging`` determines the log level internally.
+    setup_logging()
     logger.info(
         "Parameters received: folder_ids=%s, filename_mov=%s, filename_ref=%s, "
         "area_m2=%s, radius=%s, k=%s, sample_size=%s, use_convex_hull=%s, "

--- a/m3c2/core/statistics/exporters.py
+++ b/m3c2/core/statistics/exporters.py
@@ -192,8 +192,10 @@ def write_cloud_stats(
 
     if isinstance(rows, pd.DataFrame):
         df = rows.copy()
-    else:
+    elif rows:
         df = pd.DataFrame(rows, columns=list(rows[0].keys()))
+    else:
+        df = pd.DataFrame()
 
     if df.empty:
         logger.info("Skipping writing cloud stats to %s - no data", out_path)

--- a/m3c2/io/filename_services/delete_filename.py
+++ b/m3c2/io/filename_services/delete_filename.py
@@ -11,7 +11,7 @@ dry-run mode to preview changes without modifying the filesystem.
 import argparse, os, logging
 from pathlib import Path
 
-from m3c2.io.logging_utils import resolve_log_level, setup_logging
+from m3c2.io.logging_utils import setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,8 @@ def main():
     ap.add_argument("-n", "--dry-run", action="store_true", help="Nur anzeigen, nichts ändern")
     args = ap.parse_args()
 
-    setup_logging(level=resolve_log_level())
+    # Initialize logging using configuration defaults and environment values.
+    setup_logging()
 
     base = Path(args.path).resolve()
     changed = skipped = 0

--- a/m3c2/io/filename_services/rename_filename.py
+++ b/m3c2/io/filename_services/rename_filename.py
@@ -11,7 +11,7 @@ dry-run mode and optional recursion into subdirectories.
 import re, argparse, os, logging
 from pathlib import Path
 
-from m3c2.io.logging_utils import resolve_log_level, setup_logging
+from m3c2.io.logging_utils import setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,8 @@ def main():
     ap.add_argument("-n", "--dry-run", action="store_true", help="Nur anzeigen, nichts ändern")
     args = ap.parse_args()
 
-    setup_logging(level=resolve_log_level())
+    # Logging configuration uses project defaults; no explicit level required.
+    setup_logging()
 
     base = Path(args.path).resolve()
     changed = skipped = 0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-"""Test suite for the M3C2 project.
-
-This package collects unit tests that verify the project's
-components and guard against regressions.
-"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Pytest configuration and shared fixtures for the test suite.
+
+This module ensures that the project's root directory is available on
+``sys.path`` so that tests can import the local ``m3c2`` package without
+requiring an installed distribution.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))

--- a/tests/test_cli/test_plot_report.py
+++ b/tests/test_cli/test_plot_report.py
@@ -28,7 +28,8 @@ def test_main_builds_pdfs(tmp_path, monkeypatch):
         "build_parts_pdf",
         staticmethod(fake_build_parts_pdf),
     )
-    monkeypatch.setattr(plot_report, "setup_logging", lambda level=None: None)
+    # ``setup_logging`` no longer accepts parameters.
+    monkeypatch.setattr(plot_report, "setup_logging", lambda: None)
 
     pdf_incl, pdf_excl = plot_report.main(data_dir=str(tmp_path), out_dir=str(tmp_path))
 

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 import m3c2.io.logging_utils as logging_utils
 
 
-def test_setup_logging_idempotent(tmp_path: Path) -> None:
+def test_setup_logging_idempotent(tmp_path: Path, monkeypatch) -> None:
     """Verify that repeated logging configuration calls have no side effects.
 
     Parameters
@@ -28,9 +26,8 @@ def test_setup_logging_idempotent(tmp_path: Path) -> None:
     --------
     >>> from pathlib import Path
     >>> from m3c2.io.logging_utils import setup_logging
-    >>> log_file = Path("example.log")
-    >>> setup_logging(log_file=str(log_file))
-    >>> setup_logging(log_file=str(log_file))
+    >>> setup_logging()
+    >>> setup_logging()
     """
     logger = logging.getLogger()
     # ensure clean logger state
@@ -38,11 +35,12 @@ def test_setup_logging_idempotent(tmp_path: Path) -> None:
         logger.removeHandler(handler)
 
     log_file = tmp_path / "test.log"
+    monkeypatch.setenv("LOG_FILE", str(log_file))
 
-    logging_utils.setup_logging(log_file=str(log_file))
+    logging_utils.setup_logging()
     handlers_before = list(logger.handlers)
 
-    logging_utils.setup_logging(log_file=str(log_file))
+    logging_utils.setup_logging()
     handlers_after = list(logger.handlers)
 
     assert handlers_after == handlers_before
@@ -51,6 +49,7 @@ def test_setup_logging_idempotent(tmp_path: Path) -> None:
     # cleanup
     for handler in list(logger.handlers):
         logger.removeHandler(handler)
+    monkeypatch.delenv("LOG_FILE", raising=False)
 
 
 def test_fatal_alias() -> None:

--- a/tests/test_pipeline/test_archive/test_outlier_handler.py
+++ b/tests/test_pipeline/test_archive/test_outlier_handler.py
@@ -23,16 +23,22 @@ def test_exclude_outliers(monkeypatch):
 
     called = {}
 
-    def fake_exclude_outliers(data_folder, ref_variant, method, outlier_multiplicator):
-        called["args"] = (data_folder, ref_variant, method, outlier_multiplicator)
+    def fake_exclude_outliers(dists_path, method, outlier_multiplicator):
+        called["args"] = (dists_path, method, outlier_multiplicator)
 
     monkeypatch.setattr(
-        "m3c2.pipeline.outlier_handler.exclude_outliers", fake_exclude_outliers
+        "m3c2.archive_moduls.outlier_handler.exclude_outliers",
+        fake_exclude_outliers,
     )
 
-    cfg = SimpleNamespace(outlier_detection_method="iqr", outlier_multiplicator=2.5)
+    cfg = SimpleNamespace(
+        outlier_detection_method="iqr",
+        outlier_multiplicator=2.5,
+        process_python_CC="python",
+    )
     handler = OutlierHandler()
 
     handler.exclude_outliers(cfg, out_base="base", tag="tag")
 
-    assert called["args"] == ("base", "tag", "iqr", 2.5)
+    expected_path = "base/python_tag_m3c2_distances_coordinates.txt"
+    assert called["args"] == (expected_path, "iqr", 2.5)


### PR DESCRIPTION
## Summary
- ensure tests can import package by adding project root to sys.path via `tests/conftest.py`
- remove obsolete logging parameters and use new `setup_logging()` API
- handle empty statistics rows safely in `write_cloud_stats`
- align tests with updated pipeline and logging behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8401c7ab08323bafdd20b00ec79f9