### PR TITLE
refactor: centralize NMAD scaling

### DIFF
--- a/m3c2/statistics/distance_basic_metrics.py
+++ b/m3c2/statistics/distance_basic_metrics.py
@@ -14,6 +14,7 @@ import logging
 import numpy as np
 import pandas as pd
 from scipy.stats import norm, weibull_min
+from .distance_outlier_metrics import NMAD_SCALE
 
 
 logger = logging.getLogger(__name__)
@@ -90,7 +91,7 @@ def basic_stats(values: np.ndarray, tolerance: float) -> Dict[str, float]:
     std_emp = float(np.std(values))
     mae = float(np.mean(np.abs(values)))
     mad = float(np.median(np.abs(values - median_val)))
-    nmad = float(1.4826 * mad)
+    nmad = float(NMAD_SCALE * mad)
     q05 = float(np.percentile(values, 5))
     q25 = float(np.percentile(values, 25))
     q75 = float(np.percentile(values, 75))

--- a/m3c2/statistics/distance_outlier_metrics.py
+++ b/m3c2/statistics/distance_outlier_metrics.py
@@ -16,6 +16,9 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+# Scale factor to convert median absolute deviation to normalized MAD
+NMAD_SCALE = 1.4826
+
 
 def get_outlier_mask(clipped, method, outlier_multiplicator):
     """Create a boolean mask marking elements considered outliers.
@@ -74,7 +77,7 @@ def get_outlier_mask(clipped, method, outlier_multiplicator):
         )
     elif method == "nmad":
         med = np.median(clipped)
-        nmad = 1.4826 * np.median(np.abs(clipped - med))
+        nmad = NMAD_SCALE * np.median(np.abs(clipped - med))
         outlier_threshold = outlier_multiplicator * nmad
         outlier_mask = np.abs(clipped - med) > outlier_threshold
         logger.info(


### PR DESCRIPTION
## Summary
- define `NMAD_SCALE` constant for NMAD computations
- reuse `NMAD_SCALE` in `distance_outlier_metrics` and `distance_basic_metrics`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'comparedist_plots' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8828ad50083239e1cc89f661d5871