### PR TITLE
Allow comma-separated folder input in GUI

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -51,7 +51,7 @@
         },
         "folders": {
           "type": "array",
-          "description": "List of folders containing point clouds.",
+          "description": "List of folders containing point clouds (comma-separated in GUI).",
           "items": { "type": "string" },
           "default": ["pointclouds"]
         },


### PR DESCRIPTION
## Summary
- permit comma-separated folder lists in the GUI argument collector
- display default list values without brackets
- note comma-separated folders in schema and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba844fe5fc8323a22a06fd75d24b73