### PR TITLE
Respect blank GUI inputs over config defaults

### DIFF
--- a/m3c2/cli/cli.py
+++ b/m3c2/cli/cli.py
@@ -181,8 +181,14 @@ class CLIApp:
         """Parse command line arguments using the configured parser."""
         parser = self.build_parser()
 
-        # Load defaults from configuration file if available
-        if self.config_path.exists():
+        # Load defaults from configuration file only when no explicit
+        # argument list is provided. The GUI supplies an ``argv`` list
+        # built from user input. If a field is left empty in the GUI, it
+        # should not fall back to values from ``config.json``. By skipping
+        # the config defaults when ``argv`` is given, empty GUI fields
+        # retain the parser's defaults (typically ``""`` or ``None``),
+        # thus truly overriding any config settings.
+        if argv is None and self.config_path.exists():
             try:
                 with self.config_path.open("r", encoding="utf-8") as handle:
                     data: dict[str, Any] = json.load(handle)

--- a/tests/test_cli/test_cli_app.py
+++ b/tests/test_cli/test_cli_app.py
@@ -45,7 +45,20 @@ def test_run_invokes_orchestrator(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("m3c2.cli.cli.BatchOrchestrator", orchestrator_cls)
 
     app = CLIApp()
-    result = app.run(["--data_dir", str(tmp_path), "--folders", "001"])
+    result = app.run(
+        [
+            "--data_dir",
+            str(tmp_path),
+            "--folders",
+            "001",
+            "--stats_singleordistance",
+            "distance",
+            "--filename_ref",
+            "ref",
+            "--filename_mov",
+            "mov",
+        ]
+    )
 
     assert result == 0
     orchestrator_cls.assert_called_once()


### PR DESCRIPTION
## Summary
- Avoid loading config.json defaults when explicit argument lists are provided (e.g. from GUI)
- Update CLI test to provide minimal required arguments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba8883c17483238e43e74d285b0df6