### PR TITLE
refactor: centralize square limits helper

### DIFF
--- a/m3c2/visualization/plot_helpers.py
+++ b/m3c2/visualization/plot_helpers.py
@@ -12,6 +12,34 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+# NOTE: `_square_limits` is a small helper that ensures axis limits are
+# square and padded slightly so all points are visible.  It is used by
+# several plotters.
+def _square_limits(x: np.ndarray, y: np.ndarray, pad: float = 0.05) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Return square axis limits covering the ``x`` and ``y`` data.
+
+    Parameters
+    ----------
+    x, y:
+        Arrays of x and y coordinates.
+    pad:
+        Fractional padding applied to the half-width of the square.
+
+    Returns
+    -------
+    tuple[tuple[float, float], tuple[float, float]]
+        ``(x_limits, y_limits)`` where each is a ``(min, max)`` tuple.
+    """
+
+    x_min, x_max = float(np.min(x)), float(np.max(x))
+    y_min, y_max = float(np.min(y)), float(np.max(y))
+    v_min = min(x_min, y_min)
+    v_max = max(x_max, y_max)
+    cx = cy = (v_min + v_max) / 2.0
+    half = max((x_max - x_min), (y_max - y_min)) / 2.0
+    half = half * (1.0 + pad) if half > 0 else 1.0
+    return (cx - half, cx + half), (cy - half, cy + half)
+
 # seaborn is optional; importing it lazily keeps dependencies light
 try:  # pragma: no cover - tested via monkeypatch
     import seaborn as sns  # type: ignore
@@ -63,5 +91,5 @@ def histogram(
     plt.close()
 
 
-__all__ = ["histogram"]
+__all__ = ["_square_limits", "histogram"]
 

--- a/m3c2/visualization/plotters/linear_regression_plotter.py
+++ b/m3c2/visualization/plotters/linear_regression_plotter.py
@@ -15,34 +15,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from ..loaders.comparison_loader import _load_and_mask
+from ..plot_helpers import _square_limits
 
 logger = logging.getLogger(__name__)
-
-
-def _square_limits(x: np.ndarray, y: np.ndarray, pad: float = 0.05):
-    """Return square axis limits covering the ``x`` and ``y`` data.
-
-    Parameters
-    ----------
-    x, y:
-        Arrays of x and y coordinates.
-    pad:
-        Fractional padding applied to the half-width of the square.
-
-    Returns
-    -------
-    tuple[tuple[float, float], tuple[float, float]]
-        ``(x_limits, y_limits)`` where each is a ``(min, max)`` tuple.
-    """
-
-    x_min, x_max = float(np.min(x)), float(np.max(x))
-    y_min, y_max = float(np.min(y)), float(np.max(y))
-    v_min = min(x_min, y_min)
-    v_max = max(x_max, y_max)
-    cx = cy = (v_min + v_max) / 2.0
-    half = max((x_max - x_min), (y_max - y_min)) / 2.0
-    half = half * (1.0 + pad) if half > 0 else 1.0
-    return (cx - half, cx + half), (cy - half, cy + half)
 
 
 def linear_regression_plot(

--- a/m3c2/visualization/plotters/passing_bablok_plotter.py
+++ b/m3c2/visualization/plotters/passing_bablok_plotter.py
@@ -16,21 +16,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from ..loaders.comparison_loader import _load_and_mask
+from ..plot_helpers import _square_limits
 
 logger = logging.getLogger(__name__)
-
-
-def _square_limits(x: np.ndarray, y: np.ndarray, pad: float = 0.05):
-    """Return square axis limits covering all points with a small padding."""
-    x_min, x_max = float(np.min(x)), float(np.max(x))
-    y_min, y_max = float(np.min(y)), float(np.max(y))
-    v_min = min(x_min, y_min)
-    v_max = max(x_max, y_max)
-    cx = cy = (v_min + v_max) / 2.0
-    half = max((x_max - x_min), (y_max - y_min)) / 2.0
-    half = half * (1.0 + pad) if half > 0 else 1.0
-    return (cx - half, cx + half), (cy - half, cy + half)
-
 
 def passing_bablok_plot(
     folder_ids: List[str],


### PR DESCRIPTION
## Summary
- move `_square_limits` into common `plot_helpers` module
- reuse shared helper in Passing–Bablok and linear regression plotters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bad97b9ee483239dcece1bcea49492