### PR TITLE
feat: add plot generation modes to GUI

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -96,8 +96,8 @@
         },
         "stats_singleordistance": {
           "type": "string",
-          "description": "Statistics type: 'single' for single-cloud statistics or 'distance' for pairwise distance analysis.",
-          "enum": ["single", "distance"],
+          "description": "Operation mode: 'single' for single-cloud statistics, 'distance' for pairwise distance analysis, or 'plot' to create plots from existing distance files.",
+          "enum": ["single", "distance", "plot"],
           "default": "single"
         },
         "output_format": {

--- a/m3c2/cli/argparse_gui.py
+++ b/m3c2/cli/argparse_gui.py
@@ -42,7 +42,13 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
         (a for a in parser._actions if getattr(a, "dest", "") == "stats_singleordistance"),
         None,
     )
+    plot_action = next(
+        (a for a in parser._actions if getattr(a, "dest", "") == "plot_strategy"),
+        None,
+    )
     mode_var: tk.StringVar | None = None
+    plot_var: tk.StringVar | None = None
+    plot_widgets: list[tk.Widget] = []
 
     if mode_action is not None:
         tk.Label(root, text="Modus").grid(row=row, column=0, sticky="w", padx=5, pady=5)
@@ -52,7 +58,7 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
             text="Distanz Calculation (M3C2)",
             variable=mode_var,
             value="distance",
-            command=lambda: _update_mode_fields(mode_var, widgets),
+            command=lambda: _update_mode_fields(mode_var, widgets, plot_var, plot_widgets),
         ).grid(row=row, column=1, sticky="w", padx=5, pady=5)
         row += 1
         tk.Radiobutton(
@@ -60,9 +66,53 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
             text="Single Cloud Statistiks",
             variable=mode_var,
             value="single",
-            command=lambda: _update_mode_fields(mode_var, widgets),
+            command=lambda: _update_mode_fields(mode_var, widgets, plot_var, plot_widgets),
         ).grid(row=row, column=1, sticky="e", padx=5, pady=5)
         row += 1
+        if "plot" in getattr(mode_action, "choices", []):
+            tk.Radiobutton(
+                root,
+                text="Plots from Distances",
+                variable=mode_var,
+                value="plot",
+                command=lambda: _update_mode_fields(mode_var, widgets, plot_var, plot_widgets),
+            ).grid(row=row, column=1, sticky="w", padx=5, pady=5)
+            row += 1
+            if plot_action is not None:
+                tk.Label(root, text="Plot Strategie").grid(
+                    row=row, column=0, sticky="w", padx=5, pady=5
+                )
+                plot_var = tk.StringVar(value=str(plot_action.default or "specificfile"))
+                rb = tk.Radiobutton(
+                    root,
+                    text="Dateien in Ordner",
+                    variable=plot_var,
+                    value="onefolder",
+                    command=lambda: _update_mode_fields(mode_var, widgets, plot_var, plot_widgets),
+                )
+                rb.grid(row=row, column=1, sticky="w", padx=5, pady=5)
+                plot_widgets.append(rb)
+                row += 1
+                rb = tk.Radiobutton(
+                    root,
+                    text="Mehrere Ordner",
+                    variable=plot_var,
+                    value="severalfolders",
+                    command=lambda: _update_mode_fields(mode_var, widgets, plot_var, plot_widgets),
+                )
+                rb.grid(row=row, column=1, sticky="w", padx=5, pady=5)
+                plot_widgets.append(rb)
+                row += 1
+                rb = tk.Radiobutton(
+                    root,
+                    text="Spezifische Dateien",
+                    variable=plot_var,
+                    value="specificfile",
+                    command=lambda: _update_mode_fields(mode_var, widgets, plot_var, plot_widgets),
+                )
+                rb.grid(row=row, column=1, sticky="w", padx=5, pady=5)
+                plot_widgets.append(rb)
+                row += 1
 
     bool_action = getattr(argparse, "BooleanOptionalAction", None)
 
@@ -71,6 +121,8 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
         if isinstance(action, argparse._HelpAction):
             continue
         if mode_action is not None and action is mode_action:
+            continue
+        if plot_action is not None and action is plot_action:
             continue
 
         tk.Label(root, text=action.dest).grid(row=row, column=0, sticky="w", padx=5, pady=5)
@@ -106,7 +158,7 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
         row += 1
 
     if mode_var is not None:
-        _update_mode_fields(mode_var, widgets)
+        _update_mode_fields(mode_var, widgets, plot_var, plot_widgets)
 
     def on_start() -> None:
         """Handle the start event by collecting arguments and executing the main function.
@@ -157,6 +209,12 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
 
         if mode_action is not None and mode_var is not None:
             argv.extend([mode_action.option_strings[0], mode_var.get()])
+            if (
+                mode_var.get() == "plot"
+                and plot_action is not None
+                and plot_var is not None
+            ):
+                argv.extend([plot_action.option_strings[0], plot_var.get()])
 
         logger.info("Start pressed with arguments: %s", argv)
         try:
@@ -201,8 +259,13 @@ def _load_arg_descriptions(schema_path):
     return {key: value.get("description", "") for key, value in arg_props.items()}
 
 
-def _update_mode_fields(mode_var: tk.StringVar, widgets: dict[str, Tuple[tk.Variable, tk.Widget]]) -> None:
-    """Enable or disable widgets depending on the selected statistics mode."""
+def _update_mode_fields(
+    mode_var: tk.StringVar,
+    widgets: dict[str, Tuple[tk.Variable, tk.Widget]],
+    plot_var: tk.StringVar | None = None,
+    plot_widgets: list[tk.Widget] | None = None,
+) -> None:
+    """Enable or disable widgets depending on the selected mode."""
 
     mode = mode_var.get()
     dist_fields = [
@@ -213,12 +276,14 @@ def _update_mode_fields(mode_var: tk.StringVar, widgets: dict[str, Tuple[tk.Vari
         "outlier_multiplicator",
     ]
     single_fields = ["filename_singlecloud"]
+    plot_specific = ["overlay_files", "overlay_outdir", "plot_types"]
+    plot_onefolder = ["folder", "overlay_outdir", "options"]
+    plot_several = ["data_dir", "folders", "filenames", "overlay_outdir", "options"]
 
     def _disable(var: tk.Variable, widget: tk.Widget) -> None:
         widget.configure(state="disabled")
-        # WICHTIG: BooleanVar nicht auf "" setzen!
         if isinstance(var, tk.BooleanVar):
-            var.set(False)  # oder True, falls gewünscht
+            var.set(False)
         else:
             var.set("")
 
@@ -243,6 +308,31 @@ def _update_mode_fields(mode_var: tk.StringVar, widgets: dict[str, Tuple[tk.Vari
             else:
                 _disable(var, widget)
 
+    # Plot-Mode-Felder
+    all_plot_fields = set(plot_specific + plot_onefolder + plot_several)
+    for name in all_plot_fields:
+        if name in widgets:
+            var, widget = widgets[name]
+            if mode == "plot":
+                strategy = plot_var.get() if plot_var is not None else "specificfile"
+                if (
+                    (strategy == "specificfile" and name in plot_specific)
+                    or (strategy == "onefolder" and name in plot_onefolder)
+                    or (strategy == "severalfolders" and name in plot_several)
+                ):
+                    _enable(widget)
+                else:
+                    _disable(var, widget)
+            else:
+                _disable(var, widget)
+
+    if plot_widgets is not None:
+        for w in plot_widgets:
+            if mode == "plot":
+                w.configure(state="normal")
+            else:
+                w.configure(state="disabled")
+
     # only_stats im Single-Mode fix auf True setzen und sperren
     if "only_stats" in widgets:
         only_var, only_widget = widgets["only_stats"]
@@ -250,7 +340,6 @@ def _update_mode_fields(mode_var: tk.StringVar, widgets: dict[str, Tuple[tk.Vari
             if isinstance(only_var, tk.BooleanVar):
                 only_var.set(True)
             else:
-                # falls aus irgendeinem Grund kein BooleanVar
                 try:
                     only_var.set("1")
                 except Exception:

--- a/m3c2/cli/cli.py
+++ b/m3c2/cli/cli.py
@@ -123,8 +123,12 @@ class CLIApp:
         parser.add_argument(
             "--stats_singleordistance",
             type=str,
-            choices=["single", "distance"],
-            help="Type of statistics to compute: 'single' for single-cloud, 'distance' for distance-based.",
+            choices=["single", "distance", "plot"],
+            help=(
+                "Type of operation: 'single' for single-cloud statistics, "
+                "'distance' for distance-based processing, or 'plot' to "
+                "generate plots from existing distance files."
+            ),
         )
         parser.add_argument(
             "--output_format",

--- a/main_gui.py
+++ b/main_gui.py
@@ -3,8 +3,12 @@
 # Imports
 import logging
 
+from pathlib import Path
+
 from m3c2.cli.argparse_gui import run_gui
 from m3c2.cli.cli import CLIApp
+from m3c2.cli import overlay_report
+from m3c2.visualization.services.plot_service import PlotService
 
 # Logging
 logger = logging.getLogger(__name__)
@@ -17,7 +21,116 @@ def main() -> None:
     logger.info("Starting GUI application")
 
     app = CLIApp()
-    run_gui(app.build_parser(), app.run)
+    parser = app.build_parser()
+
+    # Plotting specific arguments
+    parser.add_argument(
+        "--plot_strategy",
+        type=str,
+        choices=["specificfile", "onefolder", "severalfolders"],
+        help="Strategy to generate plots from existing distance files.",
+    )
+    parser.add_argument(
+        "--overlay_files",
+        type=str,
+        nargs="+",
+        help="List of specific distance files to plot.",
+    )
+    parser.add_argument(
+        "--overlay_outdir",
+        type=str,
+        help="Directory for output plots and reports.",
+    )
+    parser.add_argument(
+        "--plot_types",
+        type=str,
+        nargs="+",
+        help="Plot types to generate for specific files.",
+    )
+    parser.add_argument(
+        "--folder",
+        type=str,
+        help="Folder containing distance files to process.",
+    )
+    parser.add_argument(
+        "--options",
+        type=str,
+        nargs="+",
+        help="List of plot options to generate.",
+    )
+    parser.add_argument(
+        "--filenames",
+        type=str,
+        nargs="+",
+        help="Distance file name parts present in each folder.",
+    )
+
+    def dispatch(argv: list[str]) -> None:
+        args = parser.parse_args(argv)
+        if args.stats_singleordistance == "plot":
+            strategy = args.plot_strategy or "specificfile"
+            if strategy == "specificfile":
+                if not args.overlay_files or not args.overlay_outdir:
+                    raise ValueError("overlay_files and overlay_outdir are required")
+                overlay_report.main(args.overlay_files, args.overlay_outdir)
+            elif strategy == "onefolder":
+                if not args.folder or not args.overlay_outdir:
+                    raise ValueError("folder and overlay_outdir are required")
+                PlotService.overlay_by_index(
+                    data_dir=args.folder,
+                    outdir=args.overlay_outdir,
+                    options=args.options,
+                )
+            elif strategy == "severalfolders":
+                if (
+                    not args.data_dir
+                    or not args.folders
+                    or not args.filenames
+                    or not args.overlay_outdir
+                ):
+                    raise ValueError(
+                        "data_dir, folders, filenames and overlay_outdir are required"
+                    )
+                data_dir = Path(args.data_dir).expanduser().resolve()
+                overlay_outdir = Path(args.overlay_outdir).expanduser().resolve()
+                if not overlay_outdir.exists():
+                    overlay_outdir.mkdir(parents=True, exist_ok=True)
+                pdfs: list[str] = []
+                folders = [f.strip() for f in args.folders]
+                filenames = [f.strip() for f in args.filenames]
+                for folder in folders:
+                    folder_path = data_dir / folder
+                    data: dict[str, object] = {}
+                    for name in filenames:
+                        file_path = folder_path / f"python_{name}_m3c2_distances.txt"
+                        try:
+                            data[name] = overlay_report.load_distance_file(str(file_path))
+                        except (FileNotFoundError, ValueError):
+                            logger.warning("Skipping missing or invalid file %s", file_path)
+                    if len(data) < 2:
+                        logger.warning("Not enough distance files in %s, skipping", folder_path)
+                        continue
+                    outdir = overlay_outdir / folder
+                    outdir.mkdir(parents=True, exist_ok=True)
+                    PlotService.overlay_from_data(data, str(outdir))
+                    pdf = PlotService.build_parts_pdf(
+                        str(outdir),
+                        pdf_path=str(outdir / "report.pdf"),
+                        include_with=True,
+                        include_inlier=False,
+                    )
+                    if pdf:
+                        pdfs.append(pdf)
+                if pdfs:
+                    PlotService.merge_pdfs(
+                        pdfs, str(overlay_outdir / "combined_report.pdf")
+                    )
+            else:
+                raise ValueError(f"Unknown plot strategy: {strategy}")
+        else:
+            app.run(argv)
+
+    run_gui(parser, dispatch)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend CLI with new `plot` operation mode
- allow selecting plot strategies for existing distance files in GUI
- dispatch plot creation through new GUI options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bad969ac988323b7a21f69cb44291c