### PR TITLE
Avoid KeyError when starting GUI with plot strategy

### DIFF
--- a/m3c2/cli/argparse_gui.py
+++ b/m3c2/cli/argparse_gui.py
@@ -176,6 +176,8 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
         for action in parser._actions:
             if isinstance(action, argparse._HelpAction) or (
                 mode_action is not None and action is mode_action
+            ) or (
+                plot_action is not None and action is plot_action
             ):
                 continue
             var = widgets[action.dest][0]


### PR DESCRIPTION
## Summary
- Skip the `plot_strategy` argparse action when gathering GUI values to prevent KeyErrors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bae35723f88323927edf59c96e0675