### PR TITLE
Add job builder strategies for report pipeline

### DIFF
--- a/report_pipeline/strategies/__init__.py
+++ b/report_pipeline/strategies/__init__.py
@@ -1,0 +1,11 @@
+from .base import JobBuilder
+from .folder import FolderJobBuilder
+from .files import FilesJobBuilder
+from .multifolder import MultiFolderJobBuilder
+
+__all__ = [
+    "JobBuilder",
+    "FolderJobBuilder",
+    "FilesJobBuilder",
+    "MultiFolderJobBuilder",
+]

--- a/report_pipeline/strategies/base.py
+++ b/report_pipeline/strategies/base.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Protocols for job building strategies."""
+
+from typing import Protocol
+
+from ..domain import PlotJob
+
+
+class JobBuilder(Protocol):
+    """Protocol for objects that create :class:`~report_pipeline.domain.PlotJob` instances."""
+
+    def build_jobs(self) -> list[PlotJob]:
+        """Return a list of jobs describing plots to generate."""
+        ...

--- a/report_pipeline/strategies/files.py
+++ b/report_pipeline/strategies/files.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Strategy building jobs from explicit distance files."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from m3c2.cli.overlay_report import load_distance_file
+
+from ..domain import PlotJob, parse_label_group
+from .base import JobBuilder
+
+
+@dataclass
+class FilesJobBuilder(JobBuilder):
+    """Create :class:`PlotJob` instances from a list of files."""
+
+    files: Iterable[Path]
+    paired: bool = False
+
+    def build_jobs(self) -> list[PlotJob]:
+        files = [Path(f).expanduser().resolve() for f in self.files]
+        if self.paired and len(files) != 2:
+            raise ValueError("--paired requires exactly two files")
+
+        jobs: list[PlotJob] = []
+        for path in files:
+            if not path.exists():
+                raise FileNotFoundError(f"Distance file not found: {path}")
+            label, group = parse_label_group(path)
+            distances = load_distance_file(str(path))
+            jobs.append(PlotJob(distances=distances, label=label, group=group))
+        return jobs

--- a/report_pipeline/strategies/folder.py
+++ b/report_pipeline/strategies/folder.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Strategy producing jobs from all distance files in a folder."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from m3c2.cli.overlay_report import load_distance_file
+
+from ..domain import PlotJob, parse_label_group
+from .base import JobBuilder
+
+
+@dataclass
+class FolderJobBuilder(JobBuilder):
+    """Build jobs for every distance file within a directory."""
+
+    folder: Path
+    paired: bool = False
+
+    def build_jobs(self) -> list[PlotJob]:
+        folder = Path(self.folder).expanduser().resolve()
+        if not folder.is_dir():
+            raise FileNotFoundError(f"Folder does not exist: {folder}")
+
+        paths = sorted(p for p in folder.iterdir() if p.is_file())
+        if self.paired and len(paths) != 2:
+            raise ValueError("--paired requires exactly two files")
+
+        jobs: list[PlotJob] = []
+        for path in paths:
+            label, group = parse_label_group(path)
+            distances = load_distance_file(str(path))
+            jobs.append(PlotJob(distances=distances, label=label, group=group))
+        return jobs

--- a/report_pipeline/strategies/multifolder.py
+++ b/report_pipeline/strategies/multifolder.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Strategy assembling jobs from multiple folders and filenames."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from m3c2.cli.overlay_report import load_distance_file
+
+from ..domain import PlotJob, parse_label_group
+from .base import JobBuilder
+
+
+@dataclass
+class MultiFolderJobBuilder(JobBuilder):
+    """Build jobs from ``filenames`` located in each of ``folders``."""
+
+    data_dir: Path
+    folders: Iterable[str]
+    filenames: Iterable[str]
+    paired: bool = False
+
+    def build_jobs(self) -> list[PlotJob]:
+        base = Path(self.data_dir).expanduser().resolve()
+        jobs: list[PlotJob] = []
+        for folder in self.folders:
+            folder_path = base / folder
+            for name in self.filenames:
+                path = folder_path / name
+                if not path.exists():
+                    raise FileNotFoundError(f"Distance file not found: {path}")
+                label, group = parse_label_group(path)
+                distances = load_distance_file(str(path))
+                jobs.append(PlotJob(distances=distances, label=label, group=group))
+
+        if self.paired and len(jobs) != 2:
+            raise ValueError("--paired requires exactly two files")
+        return jobs


### PR DESCRIPTION
## Summary
- Add JobBuilder protocol and strategies for building PlotJobs from files and folders
- Implement Files, Folder, and MultiFolder job builders with validation for paired mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc9d11f9c8323bf80e74a5c04e8ed