### PR TITLE
Add plotting utilities and PDF writer

### DIFF
--- a/report_pipeline/pdf/__init__.py
+++ b/report_pipeline/pdf/__init__.py
@@ -1,0 +1,1 @@
+"""PDF helper utilities for the report pipeline."""

--- a/report_pipeline/pdf/writer.py
+++ b/report_pipeline/pdf/writer.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Utilities to persist matplotlib figures as a PDF document.
+
+The :func:`write` function accepts a sequence of matplotlib figures and stores
+them in a temporary PDF file.  Basic metadata such as title, creation date and
+the command used to invoke the program are embedded in the resulting document.
+The path to the created PDF is returned to the caller.
+"""
+
+from datetime import datetime
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.figure import Figure
+
+
+def write(figures: Iterable[Figure]) -> Path:
+    """Write ``figures`` to a PDF file and return its path.
+
+    Parameters
+    ----------
+    figures:
+        Iterable of matplotlib :class:`~matplotlib.figure.Figure` instances.  At
+        least one figure must be supplied.  The first figure is inspected for a
+        ``suptitle`` which is used as the document title.
+
+    Returns
+    -------
+    pathlib.Path
+        Location of the generated PDF document.
+    """
+
+    figures = list(figures)
+    if not figures:
+        raise ValueError("No figures supplied")
+
+    # Derive metadata
+    title = None
+    first = figures[0]
+    if first._suptitle is not None:  # type: ignore[attr-defined]
+        title = first._suptitle.get_text()  # type: ignore[union-attr]
+    title = title or "Report"
+    creation_date = datetime.now().strftime("%Y-%m-%d")
+    cmd = " ".join(sys.argv)
+
+    metadata = {"Title": title, "CreationDate": creation_date, "Creator": cmd}
+
+    fd, tmp = tempfile.mkstemp(suffix=".pdf")
+    os.close(fd)
+    pdf_path = Path(tmp)
+
+    with PdfPages(pdf_path, metadata=metadata) as pdf:
+        for fig in figures:
+            pdf.savefig(fig)
+
+    return pdf_path

--- a/report_pipeline/plotting/__init__.py
+++ b/report_pipeline/plotting/__init__.py
@@ -1,0 +1,1 @@
+"""Plotting helpers for the report pipeline."""

--- a/report_pipeline/plotting/figure_factory.py
+++ b/report_pipeline/plotting/figure_factory.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+"""Factory functions creating matplotlib figures for distance overlays.
+
+The module focuses on a single high level function :func:`make_overlay` which
+accepts a list of :class:`~report_pipeline.domain.DistanceFile` instances and
+creates one or more overlay histograms.  The function is intentionally
+lightweight – it merely loads the underlying distance series and visualises
+them using matplotlib's default colour cycle.  When ``max_per_page`` is
+smaller than the number of items, multiple figures are created.  The caller is
+responsible for further processing, for instance writing the figures to a PDF
+report.
+"""
+
+from itertools import islice
+from typing import Iterable, Iterator
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+
+from ..domain import DistanceFile
+from .loader import load_distance_series
+
+
+def _chunked(seq: Iterable[DistanceFile], size: int) -> Iterator[list[DistanceFile]]:
+    """Yield lists of *size* items taken from *seq* until exhausted."""
+
+    it = iter(seq)
+    while True:
+        chunk = list(islice(it, size))
+        if not chunk:
+            break
+        yield chunk
+
+
+def make_overlay(
+    items: list[DistanceFile],
+    title: str | None = None,
+    max_per_page: int = 6,
+    color_strategy: str = "cycle",
+) -> list[Figure]:
+    """Create overlay histogram figures for ``items``.
+
+    Parameters
+    ----------
+    items:
+        List of :class:`DistanceFile` objects describing the data to plot.
+    title:
+        Optional title applied to the first generated figure.
+    max_per_page:
+        Maximum number of data series per figure.  Items beyond this limit are
+        rendered on additional pages.
+    color_strategy:
+        Currently only ``"cycle"`` and ``"group"`` are recognised.  The
+        strategy influences colour assignment.  With ``"group"`` items sharing
+        the same ``group`` attribute receive identical colours.
+
+    Returns
+    -------
+    list[matplotlib.figure.Figure]
+        One or more matplotlib figures containing overlay histograms.
+    """
+
+    figures: list[Figure] = []
+
+    # Determine colour assignment strategy
+    if color_strategy == "group":
+        groups: dict[str | None, str] = {}
+        color_cycle = plt.rcParams["axes.prop_cycle"].by_key().get("color", [])
+        for idx, g in enumerate({item.group for item in items}):
+            groups[g] = color_cycle[idx % len(color_cycle)]
+    else:
+        groups = {}
+        color_cycle = plt.rcParams["axes.prop_cycle"].by_key().get("color", [])
+
+    for chunk_index, chunk in enumerate(_chunked(items, max_per_page)):
+        fig, ax = plt.subplots()
+        if title and chunk_index == 0:
+            ax.set_title(title)
+
+        for i, item in enumerate(chunk):
+            data = load_distance_series(item.path)
+            color = (
+                groups.get(item.group)
+                if color_strategy == "group"
+                else color_cycle[i % len(color_cycle)]
+            )
+            ax.hist(data, bins=30, histtype="step", label=item.label, color=color)
+
+        ax.set_xlabel("Distance")
+        ax.set_ylabel("Count")
+        ax.legend()
+        fig.tight_layout()
+        figures.append(fig)
+
+    return figures

--- a/report_pipeline/plotting/loader.py
+++ b/report_pipeline/plotting/loader.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Simple utilities for reading numeric distance data from text files.
+
+This module provides a lightweight :func:`load_distance_series` function that
+reads a one-dimensional series of floating point values from a path on disk.
+Only finite values are returned; non-numeric entries trigger a ``ValueError``.
+The implementation is intentionally small and does not depend on any project
+specific infrastructure which makes it easy to test in isolation.
+"""
+
+from pathlib import Path
+
+import numpy as np
+
+
+def load_distance_series(path: Path) -> np.ndarray:
+    """Return a series of floats contained in ``path``.
+
+    Parameters
+    ----------
+    path:
+        Location of a text or CSV file containing numeric values.  The file
+        may contain a single column of numbers or a comma separated list.
+
+    Returns
+    -------
+    numpy.ndarray
+        One-dimensional array containing only finite floating point values.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist.
+    ValueError
+        If the file content cannot be interpreted as numeric data.
+    """
+
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Distance file not found: {path}")
+
+    try:
+        if path.suffix.lower() == ".csv":
+            data = np.genfromtxt(path, delimiter=",", dtype=float)
+        else:
+            data = np.loadtxt(path, dtype=float)
+    except OSError as exc:  # pragma: no cover - file reading error
+        raise FileNotFoundError(path) from exc
+    except ValueError as exc:
+        raise ValueError(f"Could not read numeric data from {path}") from exc
+
+    data = np.asarray(data, dtype=float).ravel()
+    return data[np.isfinite(data)]


### PR DESCRIPTION
## Summary
- Implement `load_distance_series` to read numeric distances from CSV/text files
- Provide `make_overlay` to build histogram figures from distance files with simple colour strategies and paging
- Add PDF `write` helper saving figures with basic metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbc9f2667883238894bb382c59a3ce