### PR TITLE
Add report pipeline tests and CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,13 @@ If neither is provided, the log level defaults to the `logging.level` entry in
 | `outlier_detection_method`| string         | `"rmse"`         | Outlier detection method (`rmse`, `mad`, `nmad`, `std`). |
 | `outlier_multiplicator`   | float          | `3.0`            | Multiplicator applied by the chosen outlier method. |
 | `log_level`               | string         | `"INFO"`         | Logging level for output (overrides `logging.level`). |
+
+## Report CLI Examples
+
+The lightweight reporting pipeline can be invoked via `m3c2-report`.  Some typical commands are:
+
+```bash
+m3c2-report folder --folder results/case_07 --pattern "*_distances.txt" --out case_07.pdf
+m3c2-report multifolder --folders results/c1 results/c2 --pattern "*_dist.txt" --paired --out all_cases.pdf
+m3c2-report files --files a1.txt b1.txt a2.txt --out ai_overlay.pdf --legend
+```

--- a/tests/test_report_pipeline/test_cli_integration.py
+++ b/tests/test_report_pipeline/test_cli_integration.py
@@ -1,0 +1,21 @@
+from report_pipeline import cli
+from report_pipeline import cli
+from report_pipeline.strategies.folder import FolderJobBuilder
+from report_pipeline.strategies.files import FilesJobBuilder
+from report_pipeline.strategies.multifolder import MultiFolderJobBuilder
+
+
+def test_parse_args_creates_correct_builders(tmp_path):
+    ns = cli.parse_args(["folder", str(tmp_path)])
+    assert isinstance(ns.builder_factory(ns), FolderJobBuilder)
+
+    ns = cli.parse_args(["files", str(tmp_path / "a.txt"), str(tmp_path / "b.txt")])
+    assert isinstance(ns.builder_factory(ns), FilesJobBuilder)
+
+    ns = cli.parse_args(["multifolder", str(tmp_path), "--folders", "f1", "--filenames", "a.txt"])
+    assert isinstance(ns.builder_factory(ns), MultiFolderJobBuilder)
+
+
+def test_run_dry_run_returns_empty_list(tmp_path):
+    result = cli.run(["folder", str(tmp_path), "--dry-run"])
+    assert result == []

--- a/tests/test_report_pipeline/test_color_mapping.py
+++ b/tests/test_report_pipeline/test_color_mapping.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from report_pipeline.domain import DistanceFile
+from report_pipeline.plotting import figure_factory
+
+
+def test_group_color_strategy_assigns_same_color(monkeypatch):
+    items = [
+        DistanceFile(path=Path("a.txt"), label="a", group="g1"),
+        DistanceFile(path=Path("b.txt"), label="b", group="g2"),
+        DistanceFile(path=Path("c.txt"), label="c", group="g1"),
+    ]
+    monkeypatch.setattr(figure_factory, "load_distance_series", lambda p: [1, 2, 3])
+    fig = MagicMock()
+    ax = MagicMock()
+    monkeypatch.setattr(figure_factory.plt, "subplots", lambda: (fig, ax))
+
+    figure_factory.make_overlay(items, color_strategy="group")
+    colors = [call.kwargs.get("color") for call in ax.hist.call_args_list]
+    assert colors[0] == colors[2]
+    assert colors[0] != colors[1]


### PR DESCRIPTION
## Summary
- add report pipeline strategy and CLI tests
- test color mapping logic for grouped overlays
- document m3c2-report example commands

## Testing
- `pytest tests/test_report_pipeline -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbc9fc3fb48323908258985b4f8376