### PR TITLE
Refactor report pipeline builders to group distance files

### DIFF
--- a/report_pipeline/cli.py
+++ b/report_pipeline/cli.py
@@ -97,7 +97,15 @@ def build_parser() -> argparse.ArgumentParser:
     folder_parser = subparsers.add_parser(
         "folder", help="Process all distance files within a folder."
     )
-    folder_parser.add_argument("folder", type=Path, help="Directory containing distance files")
+    folder_parser.add_argument(
+        "folder", type=Path, help="Directory containing distance files"
+    )
+    folder_parser.add_argument(
+        "--pattern",
+        type=str,
+        default="*",
+        help="Glob pattern to select files within the folder.",
+    )
     folder_parser.add_argument(
         "--paired",
         action="store_true",
@@ -106,7 +114,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_shared_options(folder_parser)
     folder_parser.set_defaults(
         builder_factory=lambda ns: FolderJobBuilder(
-            folder=ns.folder, paired=ns.paired
+            folder=ns.folder, pattern=ns.pattern, paired=ns.paired
         )
     )
 
@@ -114,34 +122,31 @@ def build_parser() -> argparse.ArgumentParser:
     # multifolder subcommand
     # ------------------------------------------------------------------
     multifolder_parser = subparsers.add_parser(
-        "multifolder", help="Load specific files from multiple folders."
-    )
-    multifolder_parser.add_argument(
-        "data_dir", type=Path, help="Base directory containing the folders"
+        "multifolder", help="Load matching files from multiple folders."
     )
     multifolder_parser.add_argument(
         "--folders",
         nargs="+",
         required=True,
-        help="Folder names located below the base directory.",
+        type=Path,
+        help="Folders containing distance files.",
     )
     multifolder_parser.add_argument(
-        "--filenames",
-        nargs="+",
-        required=True,
-        help="File names to load from each folder.",
+        "--pattern",
+        type=str,
+        default="*",
+        help="Glob pattern identifying files to load from each folder.",
     )
     multifolder_parser.add_argument(
         "--paired",
         action="store_true",
-        help="Expect exactly two files overall; raise an error otherwise.",
+        help="Require exactly two files per overlay; raise an error otherwise.",
     )
     _add_shared_options(multifolder_parser)
     multifolder_parser.set_defaults(
         builder_factory=lambda ns: MultiFolderJobBuilder(
-            data_dir=ns.data_dir,
             folders=ns.folders,
-            filenames=ns.filenames,
+            pattern=ns.pattern,
             paired=ns.paired,
         )
     )

--- a/report_pipeline/domain.py
+++ b/report_pipeline/domain.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 import re
-from typing import Iterable, Optional, Tuple
+from typing import Optional, Tuple
 
 # Regular expression matching ``<label>__<group>`` or ``<label>--<group>`` where
 # the group part is optional.  Using a non-greedy match for the label ensures
@@ -31,11 +31,15 @@ class DistanceFile:
 
 @dataclass(frozen=True)
 class PlotJob:
-    """Data required to produce a plot for a set of distances."""
+    """Description of a single overlay plot.
 
-    distances: Iterable[float]
-    label: str
-    group: Optional[str] = None
+    The job merely collects :class:`DistanceFile` instances which are later
+    loaded by the plotting layer.  Builders are intentionally lightweight and
+    therefore never read the referenced files.
+    """
+
+    items: list[DistanceFile]
+    page_title: Optional[str] = None
 
 
 def parse_label_group(path: Path) -> Tuple[str, Optional[str]]:

--- a/tests/test_report_pipeline/test_cli_integration.py
+++ b/tests/test_report_pipeline/test_cli_integration.py
@@ -1,5 +1,4 @@
 from report_pipeline import cli
-from report_pipeline import cli
 from report_pipeline.strategies.folder import FolderJobBuilder
 from report_pipeline.strategies.files import FilesJobBuilder
 from report_pipeline.strategies.multifolder import MultiFolderJobBuilder
@@ -12,7 +11,7 @@ def test_parse_args_creates_correct_builders(tmp_path):
     ns = cli.parse_args(["files", str(tmp_path / "a.txt"), str(tmp_path / "b.txt")])
     assert isinstance(ns.builder_factory(ns), FilesJobBuilder)
 
-    ns = cli.parse_args(["multifolder", str(tmp_path), "--folders", "f1", "--filenames", "a.txt"])
+    ns = cli.parse_args(["multifolder", "--folders", str(tmp_path)])
     assert isinstance(ns.builder_factory(ns), MultiFolderJobBuilder)
 
 

--- a/tests/test_report_pipeline/test_strategies.py
+++ b/tests/test_report_pipeline/test_strategies.py
@@ -6,18 +6,33 @@ from report_pipeline.strategies.files import FilesJobBuilder
 from report_pipeline.strategies.multifolder import MultiFolderJobBuilder
 
 
-def test_folder_job_builder_sorts(tmp_path):
+def _labels(job):
+    return [item.label for item in job.items]
+
+
+def _groups(job):
+    return [item.group for item in job.items]
+
+
+def test_folder_job_builder_sorts(tmp_path: Path) -> None:
     (tmp_path / "b__g.txt").write_text("1\n")
     (tmp_path / "a__g.txt").write_text("2\n")
     builder = FolderJobBuilder(folder=tmp_path)
     jobs = builder.build_jobs()
-    labels = [job.label for job in jobs]
-    assert labels == ["a", "b"]
-    groups = [job.group for job in jobs]
-    assert groups == ["g", "g"]
+    assert [_labels(j) for j in jobs] == [["a"], ["b"]]
+    assert [_groups(j) for j in jobs] == [["g"], ["g"]]
 
 
-def test_files_job_builder_missing_file(tmp_path):
+def test_folder_job_builder_pattern_and_paired(tmp_path: Path) -> None:
+    for name in ["a1.txt", "a2.txt", "b1.txt", "b2.txt"]:
+        (tmp_path / name).write_text("1\n")
+    builder = FolderJobBuilder(folder=tmp_path, pattern="a*.txt", paired=True)
+    jobs = builder.build_jobs()
+    assert len(jobs) == 1
+    assert [p.path.name for p in jobs[0].items] == ["a1.txt", "a2.txt"]
+
+
+def test_files_job_builder_missing_file(tmp_path: Path) -> None:
     existing = tmp_path / "a.txt"
     existing.write_text("1\n")
     missing = tmp_path / "missing.txt"
@@ -26,17 +41,28 @@ def test_files_job_builder_missing_file(tmp_path):
         builder.build_jobs()
 
 
-def test_multifolder_job_builder(tmp_path):
-    base = tmp_path
-    for folder in ["f1", "f2"]:
-        sub = base / folder
-        sub.mkdir()
-        (sub / "d1__g1.txt").write_text("1\n")
-        (sub / "d2__g2.txt").write_text("2\n")
-    builder = MultiFolderJobBuilder(
-        data_dir=base, folders=["f1", "f2"], filenames=["d1__g1.txt", "d2__g2.txt"]
-    )
+def test_files_job_builder_paired(tmp_path: Path) -> None:
+    paths = []
+    for name in ["a.txt", "b.txt", "c.txt", "d.txt"]:
+        p = tmp_path / name
+        p.write_text("1\n")
+        paths.append(p)
+    builder = FilesJobBuilder(files=paths, paired=True)
     jobs = builder.build_jobs()
-    assert len(jobs) == 4
-    labels = [job.label for job in jobs]
-    assert labels == ["d1", "d2", "d1", "d2"]
+    assert len(jobs) == 2
+    assert all(len(job.items) == 2 for job in jobs)
+
+
+def test_multifolder_job_builder(tmp_path: Path) -> None:
+    f1 = tmp_path / "f1"
+    f2 = tmp_path / "f2"
+    f1.mkdir()
+    f2.mkdir()
+    for folder in [f1, f2]:
+        (folder / "d1__g1.txt").write_text("1\n")
+        (folder / "d2__g2.txt").write_text("2\n")
+    builder = MultiFolderJobBuilder(folders=[f1, f2], pattern="*.txt")
+    jobs = builder.build_jobs()
+    assert len(jobs) == 2
+    assert [_labels(j) for j in jobs] == [["d1", "d1"], ["d2", "d2"]]
+    assert [_groups(j) for j in jobs] == [["g1", "g1"], ["g2", "g2"]]


### PR DESCRIPTION
## Summary
- Build overlay jobs from file paths instead of loading data
- Add pattern and pairing support to job builders and CLI
- Provide tests for file grouping and pairing behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbd70f6f988323835fb295aff370d6