### PR TITLE
feat: customize pdf writer output

### DIFF
--- a/report_pipeline/orchestrator.py
+++ b/report_pipeline/orchestrator.py
@@ -24,8 +24,9 @@ class ReportOrchestrator:
         plotter:
             Object providing a ``make_overlay`` method returning a figure.
         pdf_writer:
-            Object providing a ``write`` method accepting a sequence of figures
-            and returning the path to the generated PDF report.
+            Object providing a ``write`` method accepting a sequence of figures,
+            an output path and a document title, returning the path to the
+            generated PDF report.
         builder:
             Instance capable of creating :class:`~report_pipeline.domain.PlotJob`
             objects via :meth:`~report_pipeline.strategies.base.JobBuilder.build_jobs`.
@@ -35,7 +36,7 @@ class ReportOrchestrator:
         self.pdf_writer = pdf_writer
         self.builder = builder
 
-    def run(self) -> Path:
+    def run(self, out_path: Path, title: str) -> Path:
         """Generate figures for the builder's jobs and write them to a PDF report."""
 
         jobs = self.builder.build_jobs()
@@ -43,5 +44,5 @@ class ReportOrchestrator:
         for job in jobs:
             figs = self.plotter.make_overlay(job.items, title=job.page_title)
             figures.extend(figs)
-        pdf_path = self.pdf_writer.write(figures)
+        pdf_path = self.pdf_writer.write(figures, out_path, title)
         return pdf_path

--- a/report_pipeline/pdf/writer.py
+++ b/report_pipeline/pdf/writer.py
@@ -3,15 +3,13 @@ from __future__ import annotations
 """Utilities to persist matplotlib figures as a PDF document.
 
 The :func:`write` function accepts a sequence of matplotlib figures and stores
-them in a temporary PDF file.  Basic metadata such as title, creation date and
-the command used to invoke the program are embedded in the resulting document.
-The path to the created PDF is returned to the caller.
+them in a PDF file.  Basic metadata such as title, creation date and the
+command used to invoke the program are embedded in the resulting document.  The
+path to the created PDF is returned to the caller.
 """
 
 from datetime import datetime
-import os
 import sys
-import tempfile
 from pathlib import Path
 from typing import Iterable
 
@@ -19,15 +17,18 @@ from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.figure import Figure
 
 
-def write(figures: Iterable[Figure]) -> Path:
-    """Write ``figures`` to a PDF file and return its path.
+def write(figures: Iterable[Figure], out_path: Path, title: str) -> Path:
+    """Write ``figures`` to ``out_path`` and return that path.
 
     Parameters
     ----------
     figures:
         Iterable of matplotlib :class:`~matplotlib.figure.Figure` instances.  At
-        least one figure must be supplied.  The first figure is inspected for a
-        ``suptitle`` which is used as the document title.
+        least one figure must be supplied.
+    out_path:
+        Target location where the PDF should be written.
+    title:
+        Title embedded into the PDF metadata.
 
     Returns
     -------
@@ -40,22 +41,13 @@ def write(figures: Iterable[Figure]) -> Path:
         raise ValueError("No figures supplied")
 
     # Derive metadata
-    title = None
-    first = figures[0]
-    if first._suptitle is not None:  # type: ignore[attr-defined]
-        title = first._suptitle.get_text()  # type: ignore[union-attr]
-    title = title or "Report"
     creation_date = datetime.now().strftime("%Y-%m-%d")
     cmd = " ".join(sys.argv)
 
     metadata = {"Title": title, "CreationDate": creation_date, "Creator": cmd}
 
-    fd, tmp = tempfile.mkstemp(suffix=".pdf")
-    os.close(fd)
-    pdf_path = Path(tmp)
-
-    with PdfPages(pdf_path, metadata=metadata) as pdf:
+    with PdfPages(out_path, metadata=metadata) as pdf:
         for fig in figures:
             pdf.savefig(fig)
 
-    return pdf_path
+    return out_path

--- a/tests/test_report_pipeline/test_orchestrator.py
+++ b/tests/test_report_pipeline/test_orchestrator.py
@@ -25,8 +25,9 @@ def test_orchestrator_flattens_figures():
     builder.build_jobs.return_value = jobs
 
     orchestrator = ReportOrchestrator(plotter, pdf_writer, builder)
-    result = orchestrator.run()
+    out_path = Path("out.pdf")
+    result = orchestrator.run(out_path, "Title")
 
     builder.build_jobs.assert_called_once_with()
-    pdf_writer.write.assert_called_once_with([fig1, fig2, fig3])
+    pdf_writer.write.assert_called_once_with([fig1, fig2, fig3], out_path, "Title")
     assert result == Path("out.pdf")

--- a/tests/test_report_pipeline/test_pdf_writer.py
+++ b/tests/test_report_pipeline/test_pdf_writer.py
@@ -4,11 +4,11 @@ import matplotlib.pyplot as plt
 from report_pipeline.pdf import writer
 
 
-def test_write_creates_pdf():
+def test_write_creates_pdf(tmp_path):
     fig, ax = plt.subplots()
     ax.plot([1, 2], [3, 4])
-    fig.suptitle('Demo')
-    pdf_path = writer.write([fig])
+    out_path = tmp_path / "out.pdf"
+    pdf_path = writer.write([fig], out_path, "Demo")
     plt.close(fig)
     assert pdf_path.exists()
     assert pdf_path.suffix == '.pdf'


### PR DESCRIPTION
## Summary
- allow PDF writer to save to a given path and embed a custom title
- propagate new arguments through report orchestrator
- update tests for new writer interface

## Testing
- `pytest tests/test_report_pipeline/test_pdf_writer.py tests/test_report_pipeline/test_orchestrator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbe4880a1c832396202608d5c5e1e9