### PR TITLE
feat: add plot type overlays to report pipeline

### DIFF
--- a/report_pipeline/cli.py
+++ b/report_pipeline/cli.py
@@ -72,6 +72,13 @@ def _add_shared_options(parser: argparse.ArgumentParser) -> None:
         help="Strategy for assigning colors to plots.",
     )
     parser.add_argument(
+        "--plot-type",
+        dest="plot_type",
+        choices=["histogram", "gauss", "weibull", "boxplot", "qq", "violin"],
+        default="histogram",
+        help="Type of overlay plot to generate.",
+    )
+    parser.add_argument(
         "--legend",
         action="store_true",
         help="Include a legend in the plots.",
@@ -121,6 +128,7 @@ def build_parser() -> argparse.ArgumentParser:
             pattern=ns.pattern,
             paired=ns.paired,
             group_by_folder=ns.group_by_folder,
+            plot_type=ns.plot_type,
         )
     )
 
@@ -153,6 +161,7 @@ def build_parser() -> argparse.ArgumentParser:
             folders=ns.folders,
             pattern=ns.pattern,
             paired=ns.paired,
+            plot_type=ns.plot_type,
         )
     )
 
@@ -176,7 +185,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_shared_options(files_parser)
     files_parser.set_defaults(
         builder_factory=lambda ns: FilesJobBuilder(
-            files=ns.files, paired=ns.paired
+            files=ns.files, paired=ns.paired, plot_type=ns.plot_type
         )
     )
 

--- a/report_pipeline/domain.py
+++ b/report_pipeline/domain.py
@@ -51,6 +51,7 @@ class PlotJob:
 
     items: list[DistanceFile]
     page_title: Optional[str] = None
+    plot_type: str = "histogram"
 
 
 def parse_label_group(path: Path) -> Tuple[str, Optional[str]]:

--- a/report_pipeline/orchestrator.py
+++ b/report_pipeline/orchestrator.py
@@ -42,7 +42,8 @@ class ReportOrchestrator:
         jobs = self.builder.build_jobs()
         figures: list = []
         for job in jobs:
-            figs = self.plotter.make_overlay(job.items, title=job.page_title)
+            plot_type = getattr(job, "plot_type", "histogram")
+            figs = self.plotter.make_overlay(job.items, title=job.page_title, plot_type=plot_type)
             figures.extend(figs)
         pdf_path = self.pdf_writer.write(figures, out_path, title)
         return pdf_path

--- a/report_pipeline/plotting/figure_factory.py
+++ b/report_pipeline/plotting/figure_factory.py
@@ -16,12 +16,17 @@ from itertools import islice
 from hashlib import sha256
 from typing import Iterable, Iterator
 
+import logging
+import numpy as np
+import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
+from scipy.stats import norm, weibull_min, probplot
 
 from ..domain import DistanceFile
 from .loader import load_distance_series
 
+logger = logging.getLogger(__name__)
 
 def _chunked(seq: Iterable[DistanceFile], size: int) -> Iterator[list[DistanceFile]]:
     """Yield lists of *size* items taken from *seq* until exhausted."""
@@ -34,13 +39,120 @@ def _chunked(seq: Iterable[DistanceFile], size: int) -> Iterator[list[DistanceFi
         yield chunk
 
 
+def _overlay_histogram(ax, data, colors) -> None:
+    for label, arr in data.items():
+        ax.hist(arr, bins=30, histtype="step", label=label, color=colors.get(label))
+    ax.set_xlabel("Distance")
+    ax.set_ylabel("Count")
+
+
+def _overlay_gauss(ax, data, colors) -> None:
+    if not data:
+        return
+    all_vals = np.concatenate(list(data.values()))
+    x = np.linspace(float(np.min(all_vals)), float(np.max(all_vals)), 500)
+    for label, arr in data.items():
+        mu = float(np.mean(arr))
+        std = float(np.std(arr))
+        ax.plot(
+            x,
+            norm.pdf(x, mu, std),
+            color=colors.get(label),
+            linestyle="--" if label.lower() != "cc" else "-",
+            linewidth=2,
+            label=rf"{label} Gauss (\mu={mu:.4f}, \sigma={std:.4f})",
+        )
+    ax.set_xlabel("M3C2 distance")
+    ax.set_ylabel("Density")
+
+
+def _overlay_weibull(ax, data, colors) -> None:
+    if not data:
+        return
+    all_vals = np.concatenate(list(data.values()))
+    x = np.linspace(float(np.min(all_vals)), float(np.max(all_vals)), 500)
+    for label, arr in data.items():
+        try:
+            a, loc, b = weibull_min.fit(arr)
+            ax.plot(
+                x,
+                weibull_min.pdf(x, a, loc=loc, scale=b),
+                color=colors.get(label),
+                linestyle="--" if label.lower() != "cc" else "-",
+                linewidth=2,
+                label=rf"{label} Weibull (a={a:.2f}, b={b:.4f})",
+            )
+        except (ValueError, RuntimeError) as e:
+            logger.warning("Weibull fit failed for %s: %s", label, e)
+    ax.set_xlabel("M3C2 distance")
+    ax.set_ylabel("Density")
+
+
+def _overlay_boxplot(ax, data, colors) -> None:
+    try:
+        import seaborn as sns
+
+        records = [pd.DataFrame({"Version": label, "Distanz": arr}) for label, arr in data.items()]
+        if not records:
+            return
+        df = pd.concat(records, ignore_index=True)
+        order = list(df["Version"].unique())
+        palette = {v: colors.get(v) for v in order}
+        sns.boxplot(data=df, x="Version", y="Distanz", hue="Version", palette=palette, legend=False, order=order, ax=ax)
+    except Exception:
+        labels = list(data.keys())
+        arrs = [data[v] for v in labels]
+        b = ax.boxplot(arrs, labels=labels, patch_artist=True)
+        for patch, v in zip(b["boxes"], labels):
+            c = colors.get(v, "#aaaaaa")
+            patch.set_facecolor(c)
+            patch.set_alpha(0.5)
+    ax.set_xlabel("Version")
+    ax.set_ylabel("M3C2 distance")
+
+
+def _overlay_qq(ax, data, colors) -> None:
+    for label, arr in data.items():
+        (osm, osr), (slope, intercept, r) = probplot(arr, dist="norm")
+        ax.plot(osm, osr, marker="o", linestyle="", label=label, color=colors.get(label))
+        ax.plot(osm, slope * osm + intercept, color=colors.get(label), linestyle="--", alpha=0.7)
+    ax.set_xlabel("Theoretical quantiles")
+    ax.set_ylabel("Ordered values")
+
+
+def _overlay_violin(ax, data, colors) -> None:
+    try:
+        import seaborn as sns
+
+        records = [pd.DataFrame({"Version": label, "Distanz": arr}) for label, arr in data.items()]
+        if not records:
+            return
+        df = pd.concat(records, ignore_index=True)
+        palette = {v: colors.get(v) for v in df["Version"].unique()}
+        sns.violinplot(data=df, x="Version", y="Distanz", palette=palette, cut=0, inner="quartile", ax=ax)
+    except Exception as e:
+        labels = list(data.keys())
+        arrs = [data[v] for v in labels]
+        parts = ax.violinplot(arrs, showmeans=False, showmedians=True)
+        for body, v in zip(parts["bodies"], labels):
+            c = colors.get(v, "#aaaaaa")
+            body.set_facecolor(c)
+            body.set_alpha(0.7)
+        ax.set_xticks(range(1, len(labels) + 1))
+        ax.set_xticklabels(labels)
+        logger.warning("Violinplot fallback used due to missing seaborn: %s", e)
+    ax.set_xlabel("Version")
+    ax.set_ylabel("M3C2 distance")
+
+
 def make_overlay(
     items: list[DistanceFile],
     title: str | None = None,
     max_per_page: int = 6,
     color_strategy: str = "auto",
+    plot_type: str = "histogram",
 ) -> list[Figure]:
-    """Create overlay histogram figures for ``items``.
+    """Create overlay figures for ``items``.
 
     Parameters
     ----------
@@ -56,11 +168,15 @@ def make_overlay(
         sensible default, ``"by_label"`` assigns identical colours to matching
         labels and ``"by_folder"`` groups by the parent folder name.  Colour
         selection is deterministic across calls.
+    plot_type:
+        Type of overlay plot to generate.  Supported values are ``"histogram"``,
+        ``"gauss"``, ``"weibull"``, ``"boxplot"``, ``"qq"`` and ``"violin"``.
 
     Returns
     -------
     list[matplotlib.figure.Figure]
-        One or more matplotlib figures containing overlay histograms.
+        One or more matplotlib figures containing overlay plots of the
+        requested type.
     """
 
     figures: list[Figure] = []
@@ -90,13 +206,28 @@ def make_overlay(
         if title and chunk_index == 0:
             ax.set_title(title)
 
+        data: dict[str, np.ndarray] = {}
+        colors: dict[str, str] = {}
         for item in chunk:
-            data = load_distance_series(item.path)
-            color = _colour(keyfunc(item))
-            ax.hist(data, bins=30, histtype="step", label=item.label, color=color)
+            arr = load_distance_series(item.path)
+            data[item.label] = arr
+            colors[item.label] = _colour(keyfunc(item))
 
-        ax.set_xlabel("Distance")
-        ax.set_ylabel("Count")
+        if plot_type == "histogram":
+            _overlay_histogram(ax, data, colors)
+        elif plot_type == "gauss":
+            _overlay_gauss(ax, data, colors)
+        elif plot_type == "weibull":
+            _overlay_weibull(ax, data, colors)
+        elif plot_type == "boxplot":
+            _overlay_boxplot(ax, data, colors)
+        elif plot_type == "qq":
+            _overlay_qq(ax, data, colors)
+        elif plot_type == "violin":
+            _overlay_violin(ax, data, colors)
+        else:
+            raise ValueError(f"Unknown plot type: {plot_type}")
+
         ax.legend()
         fig.tight_layout()
         figures.append(fig)

--- a/report_pipeline/strategies/files.py
+++ b/report_pipeline/strategies/files.py
@@ -16,6 +16,7 @@ class FilesJobBuilder(JobBuilder):
 
     files: Iterable[Path]
     paired: bool = False
+    plot_type: str = "histogram"
 
     def build_jobs(self) -> list[PlotJob]:
         files = [Path(f).expanduser().resolve() for f in self.files]
@@ -30,7 +31,7 @@ class FilesJobBuilder(JobBuilder):
             item = DistanceFile(path=path, label=label, group=group)
             groups.setdefault(group, []).append(item)
 
-        jobs = [PlotJob(items=items, page_title=grp) for grp, items in groups.items()]
+        jobs = [PlotJob(items=items, page_title=grp, plot_type=self.plot_type) for grp, items in groups.items()]
 
         if self.paired:
             for job in jobs:

--- a/report_pipeline/strategies/multifolder.py
+++ b/report_pipeline/strategies/multifolder.py
@@ -17,6 +17,7 @@ class MultiFolderJobBuilder(JobBuilder):
     folders: Iterable[Path]
     pattern: str = "*.txt"
     paired: bool = False
+    plot_type: str = "histogram"
 
     def build_jobs(self) -> list[PlotJob]:
         folder_paths = [Path(f).expanduser().resolve() for f in self.folders]
@@ -34,7 +35,7 @@ class MultiFolderJobBuilder(JobBuilder):
         jobs: list[PlotJob] = []
         for (label, group), items in groups.items():
             title = label if group is None else f"{label} ({group})"
-            jobs.append(PlotJob(items=items, page_title=title))
+            jobs.append(PlotJob(items=items, page_title=title, plot_type=self.plot_type))
 
         if self.paired:
             expected = len(folder_paths)

--- a/tests/test_report_pipeline/test_orchestrator.py
+++ b/tests/test_report_pipeline/test_orchestrator.py
@@ -5,9 +5,10 @@ from report_pipeline.orchestrator import ReportOrchestrator
 
 
 class Job:
-    def __init__(self, items, title):
+    def __init__(self, items, title, plot_type="histogram"):
         self.items = items
         self.page_title = title
+        self.plot_type = plot_type
 
 
 def test_orchestrator_flattens_figures():
@@ -20,7 +21,7 @@ def test_orchestrator_flattens_figures():
     pdf_writer = MagicMock()
     pdf_writer.write.return_value = Path("out.pdf")
 
-    jobs = [Job([1], "p1"), Job([2], "p2")]
+    jobs = [Job([1], "p1", "histogram"), Job([2], "p2", "gauss")]
     builder = MagicMock()
     builder.build_jobs.return_value = jobs
 
@@ -30,4 +31,6 @@ def test_orchestrator_flattens_figures():
 
     builder.build_jobs.assert_called_once_with()
     pdf_writer.write.assert_called_once_with([fig1, fig2, fig3], out_path, "Title")
+    plotter.make_overlay.assert_any_call([1], title="p1", plot_type="histogram")
+    plotter.make_overlay.assert_any_call([2], title="p2", plot_type="gauss")
     assert result == Path("out.pdf")


### PR DESCRIPTION
## Summary
- support histogram, gaussian, weibull, boxplot, qq, and violin overlays in figure factory
- expose `plot_type` throughout report pipeline and CLI
- extend orchestrator and strategies to honor selected plot type

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc0bdc729483239dd0549a702dcb20