### PR TITLE
feat: add optional legend to overlay plots

### DIFF
--- a/report_pipeline/__main__.py
+++ b/report_pipeline/__main__.py
@@ -32,13 +32,20 @@ class _Plotter:
         self.title = title
         self.plot_type = plot_type
 
-    def make_overlay(self, items, title: str | None = None, plot_type: str | None = None):
+    def make_overlay(
+        self,
+        items,
+        title: str | None = None,
+        plot_type: str | None = None,
+        show_legend: bool = False,
+    ):
         return figure_factory.make_overlay(
             items,
             title=title or self.title,
             max_per_page=self.max_per_page,
             color_strategy=self.color_mapping,
             plot_type=plot_type or self.plot_type,
+            show_legend=show_legend,
         )
 
 

--- a/report_pipeline/cli.py
+++ b/report_pipeline/cli.py
@@ -40,6 +40,39 @@ from .strategies.files import FilesJobBuilder
 BuilderFactory = Callable[[argparse.Namespace], JobBuilder]
 
 
+def _folder_builder_factory(ns: argparse.Namespace) -> FolderJobBuilder:
+    builder = FolderJobBuilder(
+        folder=ns.folder,
+        pattern=ns.pattern,
+        paired=ns.paired,
+        group_by_folder=ns.group_by_folder,
+        plot_type=ns.plot_type,
+    )
+    builder.legend = ns.legend
+    return builder
+
+
+def _multifolder_builder_factory(ns: argparse.Namespace) -> MultiFolderJobBuilder:
+    builder = MultiFolderJobBuilder(
+        folders=ns.folders,
+        pattern=ns.pattern,
+        paired=ns.paired,
+        plot_type=ns.plot_type,
+    )
+    builder.legend = ns.legend
+    return builder
+
+
+def _files_builder_factory(ns: argparse.Namespace) -> FilesJobBuilder:
+    builder = FilesJobBuilder(
+        files=ns.files,
+        paired=ns.paired,
+        plot_type=ns.plot_type,
+    )
+    builder.legend = ns.legend
+    return builder
+
+
 # ---------------------------------------------------------------------------
 # Parser construction
 # ---------------------------------------------------------------------------
@@ -133,15 +166,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Expect exactly two files; raise an error otherwise.",
     )
     _add_shared_options(folder_parser)
-    folder_parser.set_defaults(
-        builder_factory=lambda ns: FolderJobBuilder(
-            folder=ns.folder,
-            pattern=ns.pattern,
-            paired=ns.paired,
-            group_by_folder=ns.group_by_folder,
-            plot_type=ns.plot_type,
-        )
-    )
+    folder_parser.set_defaults(builder_factory=_folder_builder_factory)
 
     # ------------------------------------------------------------------
     # multifolder subcommand
@@ -167,14 +192,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Expect exactly two files overall; raise an error otherwise.",
     )
     _add_shared_options(multifolder_parser)
-    multifolder_parser.set_defaults(
-        builder_factory=lambda ns: MultiFolderJobBuilder(
-            folders=ns.folders,
-            pattern=ns.pattern,
-            paired=ns.paired,
-            plot_type=ns.plot_type,
-        )
-    )
+    multifolder_parser.set_defaults(builder_factory=_multifolder_builder_factory)
 
     # ------------------------------------------------------------------
     # files subcommand
@@ -194,11 +212,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Expect exactly two files; raise an error otherwise.",
     )
     _add_shared_options(files_parser)
-    files_parser.set_defaults(
-        builder_factory=lambda ns: FilesJobBuilder(
-            files=ns.files, paired=ns.paired, plot_type=ns.plot_type
-        )
-    )
+    files_parser.set_defaults(builder_factory=_files_builder_factory)
 
     return parser
 

--- a/report_pipeline/orchestrator.py
+++ b/report_pipeline/orchestrator.py
@@ -41,10 +41,19 @@ class ReportOrchestrator:
 
         jobs = self.builder.build_jobs()
         figures: list = []
+        try:
+            show_legend = object.__getattribute__(self.builder, "legend")
+        except AttributeError:
+            show_legend = False
         for job in jobs:
             plot_type = getattr(job, "plot_type", "histogram")
             if plot_type in {"histogram", "gauss", "weibull", "boxplot", "qq", "violin"}:
-                figs = self.plotter.make_overlay(job.items, title=job.page_title, plot_type=plot_type)
+                figs = self.plotter.make_overlay(
+                    job.items,
+                    title=job.page_title,
+                    plot_type=plot_type,
+                    show_legend=show_legend,
+                )
             elif plot_type == "bland-altman":
                 figs = self.plotter.make_bland_altman(job.items, title=job.page_title)
             elif plot_type == "linear-regression":

--- a/report_pipeline/plotting/figure_factory.py
+++ b/report_pipeline/plotting/figure_factory.py
@@ -164,6 +164,7 @@ def make_overlay(
     max_per_page: int = 6,
     color_strategy: str = "auto",
     plot_type: str = "histogram",
+    show_legend: bool = True,
 ) -> list[Figure]:
     """Create overlay figures for ``items``.
 
@@ -184,6 +185,8 @@ def make_overlay(
     plot_type:
         Type of overlay plot to generate.  Supported values are ``"histogram"``,
         ``"gauss"``, ``"weibull"``, ``"boxplot"``, ``"qq"`` and ``"violin"``.
+    show_legend:
+        Whether to render a legend on the created axes.
 
     Returns
     -------
@@ -240,8 +243,8 @@ def make_overlay(
             _overlay_violin(ax, data, colors)
         else:
             raise ValueError(f"Unknown plot type: {plot_type}")
-
-        ax.legend()
+        if show_legend:
+            ax.legend()
         fig.tight_layout()
         figures.append(fig)
 

--- a/tests/test_report_pipeline/test_orchestrator.py
+++ b/tests/test_report_pipeline/test_orchestrator.py
@@ -31,6 +31,10 @@ def test_orchestrator_flattens_figures():
 
     builder.build_jobs.assert_called_once_with()
     pdf_writer.write.assert_called_once_with([fig1, fig2, fig3], out_path, "Title")
-    plotter.make_overlay.assert_any_call([1], title="p1", plot_type="histogram")
-    plotter.make_overlay.assert_any_call([2], title="p2", plot_type="gauss")
+    plotter.make_overlay.assert_any_call(
+        [1], title="p1", plot_type="histogram", show_legend=False
+    )
+    plotter.make_overlay.assert_any_call(
+        [2], title="p2", plot_type="gauss", show_legend=False
+    )
     assert result == Path("out.pdf")


### PR DESCRIPTION
## Summary
- expose legend flag in CLI builder factories
- forward show_legend through orchestrator to figure factory
- make figure_factory.make_overlay only draw legend when requested

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc1493e84c8323b790b5a3a9bfccc4