### PR TITLE
Set default max-per-page to 4 for report pipeline CLI

### DIFF
--- a/report_pipeline/cli.py
+++ b/report_pipeline/cli.py
@@ -95,6 +95,7 @@ def _add_shared_options(parser: argparse.ArgumentParser) -> None:
         "--max-per-page",
         dest="max_per_page",
         type=int,
+        default=4,
         help="Maximum number of plots per PDF page.",
     )
     parser.add_argument(

--- a/tests/test_report_pipeline/test_cli_integration.py
+++ b/tests/test_report_pipeline/test_cli_integration.py
@@ -7,13 +7,16 @@ from report_pipeline.strategies.multifolder import MultiFolderJobBuilder
 def test_parse_args_creates_correct_builders(tmp_path):
     ns = cli.parse_args(["folder", str(tmp_path)])
     assert isinstance(ns.builder_factory(ns), FolderJobBuilder)
+    assert ns.max_per_page == 4
 
     ns = cli.parse_args(["files", str(tmp_path / "a.txt"), str(tmp_path / "b.txt")])
     assert isinstance(ns.builder_factory(ns), FilesJobBuilder)
+    assert ns.max_per_page == 4
 
     (tmp_path / "f1").mkdir()
     ns = cli.parse_args(["multifolder", "--folders", str(tmp_path / "f1")])
     assert isinstance(ns.builder_factory(ns), MultiFolderJobBuilder)
+    assert ns.max_per_page == 4
 
 
 def test_run_dry_run_returns_none(tmp_path):


### PR DESCRIPTION
## Summary
- default `--max-per-page` option to 4 in report pipeline CLI
- update CLI integration tests for new default

## Testing
- `pytest tests/test_report_pipeline/test_cli_integration.py -q`
- `pytest tests/test_report_pipeline -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc1812a50083239106b1ec534c6be2