### PR TITLE
Refine report output handling

### DIFF
--- a/report_pipeline/__main__.py
+++ b/report_pipeline/__main__.py
@@ -50,17 +50,11 @@ class _Plotter:
 
 
 class _PDFWriter:
-    """Persist figures as a report within the configured output directory."""
-
-    def __init__(self, out_dir: Path) -> None:
-        self.out_dir = out_dir
+    """Persist figures as a PDF report."""
 
     def write(self, figures, out_path: Path, title: str):
-        self.out_dir.mkdir(parents=True, exist_ok=True)
-        pdf_path = pdf_writer.write(figures)
-        target = self.out_dir / "report.pdf"
-        pdf_path.replace(target)
-        return target
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        return pdf_writer.write(figures, out_path, title)
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -71,7 +65,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         return
     builder = ns.builder_factory(ns)
     plotter = _Plotter(ns.max_per_page, ns.color_mapping, ns.title, ns.plot_type)
-    pdf_writer_instance = _PDFWriter(ns.out)
+    pdf_writer_instance = _PDFWriter()
     orchestrator = ReportOrchestrator(plotter, pdf_writer_instance, builder)
     pdf_path = orchestrator.run(ns.out, ns.title or "")
     print(pdf_path)

--- a/report_pipeline/cli.py
+++ b/report_pipeline/cli.py
@@ -83,8 +83,8 @@ def _add_shared_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--out",
         type=Path,
-        default=Path("report"),
-        help="Output directory for generated plots and report.",
+        default=Path("overlay_report.pdf"),
+        help="Path to the generated PDF report.",
     )
     parser.add_argument(
         "--title",

--- a/tests/test_report_pipeline/test_cli_integration.py
+++ b/tests/test_report_pipeline/test_cli_integration.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from report_pipeline import cli
 from report_pipeline.strategies.folder import FolderJobBuilder
 from report_pipeline.strategies.files import FilesJobBuilder
@@ -8,15 +10,18 @@ def test_parse_args_creates_correct_builders(tmp_path):
     ns = cli.parse_args(["folder", str(tmp_path)])
     assert isinstance(ns.builder_factory(ns), FolderJobBuilder)
     assert ns.max_per_page == 4
+    assert ns.out == Path("overlay_report.pdf")
 
     ns = cli.parse_args(["files", str(tmp_path / "a.txt"), str(tmp_path / "b.txt")])
     assert isinstance(ns.builder_factory(ns), FilesJobBuilder)
     assert ns.max_per_page == 4
+    assert ns.out == Path("overlay_report.pdf")
 
     (tmp_path / "f1").mkdir()
     ns = cli.parse_args(["multifolder", "--folders", str(tmp_path / "f1")])
     assert isinstance(ns.builder_factory(ns), MultiFolderJobBuilder)
     assert ns.max_per_page == 4
+    assert ns.out == Path("overlay_report.pdf")
 
 
 def test_run_dry_run_returns_none(tmp_path):


### PR DESCRIPTION
## Summary
- Simplify PDF writer integration to accept output file directly
- Treat `--out` as a PDF path with default `overlay_report.pdf`
- Update CLI tests for new default output file

## Testing
- `pytest tests/test_report_pipeline -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc19c137688323a19544bc8177343f