### PR TITLE
Validate paths for report pipeline files subcommand

### DIFF
--- a/report_pipeline/cli.py
+++ b/report_pipeline/cli.py
@@ -64,6 +64,11 @@ def _multifolder_builder_factory(ns: argparse.Namespace) -> MultiFolderJobBuilde
 
 
 def _files_builder_factory(ns: argparse.Namespace) -> FilesJobBuilder:
+    if len(ns.files) < 2:
+        raise argparse.ArgumentTypeError(
+            "At least two paths are required"
+        )
+
     builder = FilesJobBuilder(
         files=ns.files,
         paired=ns.paired,
@@ -203,7 +208,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     files_parser.add_argument(
         "files",
-        nargs="+",
+        nargs=argparse.REMAINDER,
         type=Path,
         help="Paths to distance files that should be plotted.",
     )

--- a/tests/test_report_pipeline/test_cli_integration.py
+++ b/tests/test_report_pipeline/test_cli_integration.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import argparse
+
+import pytest
 
 from report_pipeline import cli
 from report_pipeline.strategies.folder import FolderJobBuilder
@@ -27,3 +30,9 @@ def test_parse_args_creates_correct_builders(tmp_path):
 def test_run_dry_run_returns_none(tmp_path):
     result = cli.run(["folder", str(tmp_path), "--dry-run"])
     assert result is None
+
+
+def test_files_builder_requires_two_paths(tmp_path):
+    ns = cli.parse_args(["files", str(tmp_path / "a.txt")])
+    with pytest.raises(argparse.ArgumentTypeError):
+        ns.builder_factory(ns)


### PR DESCRIPTION
## Summary
- use `argparse.REMAINDER` so `files` subcommand accepts paths after options
- raise `argparse.ArgumentTypeError` when fewer than two paths are provided
- test that the `files` subcommand enforces the minimum path requirement

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc1db73cd48323abd359ab5c851587