### PR TITLE
Fix files subcommand handling of trailing options

### DIFF
--- a/report_pipeline/cli.py
+++ b/report_pipeline/cli.py
@@ -208,7 +208,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     files_parser.add_argument(
         "files",
-        nargs=argparse.REMAINDER,
+        nargs="+",
         type=Path,
         help="Paths to distance files that should be plotted.",
     )

--- a/tests/test_report_pipeline/test_cli_integration.py
+++ b/tests/test_report_pipeline/test_cli_integration.py
@@ -36,3 +36,16 @@ def test_files_builder_requires_two_paths(tmp_path):
     ns = cli.parse_args(["files", str(tmp_path / "a.txt")])
     with pytest.raises(argparse.ArgumentTypeError):
         ns.builder_factory(ns)
+
+
+def test_files_parser_recognises_trailing_options(tmp_path):
+    ns = cli.parse_args(
+        [
+            "files",
+            str(tmp_path / "a.txt"),
+            str(tmp_path / "b.txt"),
+            "--dry-run",
+        ]
+    )
+    assert ns.dry_run
+    assert ns.files == [tmp_path / "a.txt", tmp_path / "b.txt"]


### PR DESCRIPTION
## Summary
- parse file list using `nargs='+'` so trailing options remain flags
- add regression test for `files` command with trailing option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc1f7325a083238fee9cbece8897a9