### PR TITLE
Clarify multifolder paired description

### DIFF
--- a/report_pipeline/cli.py
+++ b/report_pipeline/cli.py
@@ -195,7 +195,7 @@ def build_parser() -> argparse.ArgumentParser:
     multifolder_parser.add_argument(
         "--paired",
         action="store_true",
-        help="Expect exactly two files overall; raise an error otherwise.",
+        help="Expect exactly two files per folder; raise an error otherwise.",
     )
     _add_shared_options(multifolder_parser)
     multifolder_parser.set_defaults(builder_factory=_multifolder_builder_factory)


### PR DESCRIPTION
## Summary
- clarify `--paired` description for `multifolder` command to specify two files per folder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc223e1c9883239f1102d8e99bf67f