### PR TITLE
Export M3C2 distances as PLY

### DIFF
--- a/m3c2/pipeline/multicloud_processor.py
+++ b/m3c2/pipeline/multicloud_processor.py
@@ -1,10 +1,12 @@
 import logging
+import os
 from typing import Any
 
 import numpy as np
 
 from m3c2.config.pipeline_config import PipelineConfig
 from m3c2.pipeline.param_manager import ParamManager
+from m3c2.exporter.ply_exporter import export_xyz_distance
 
 logger = logging.getLogger(__name__)
 
@@ -76,3 +78,9 @@ class MulticloudProcessor:
         distances, _, _ = self.m3c2_executor.run_m3c2(
             cfg, comparison, reference, corepoints, normal, projection, out_base, tag
         )
+
+        ply_path = os.path.join(
+            out_base, f"{cfg.process_python_CC}_{tag}_m3c2_distances.ply"
+        )
+        export_xyz_distance(corepoints, distances, ply_path)
+        logger.info("[PLY] Distanzen als PLY gespeichert: %s", ply_path)

--- a/tests/test_pipeline/test_multicloud_processor.py
+++ b/tests/test_pipeline/test_multicloud_processor.py
@@ -1,0 +1,74 @@
+"""Tests for the :mod:`m3c2.pipeline.multicloud_processor` module.
+
+This test verifies that the multicloud processor exports distances to a PLY
+file after running the M3C2 computation and that the file contains ``NaN``
+values in the distance column.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+from plyfile import PlyData
+
+from m3c2.pipeline.multicloud_processor import MulticloudProcessor
+
+
+def test_process_exports_ply_with_nan(tmp_path):
+    """Run the processor and check that a PLY file with ``NaN`` is created."""
+
+    distances = np.array([0.0, np.nan])
+    comparison = reference = corepoints = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
+    )
+
+    class DummyDataLoader:
+        def load_data(self, cfg, mode="multicloud"):
+            ds = SimpleNamespace(config=SimpleNamespace(folder=str(tmp_path)))
+            return ds, comparison, reference, corepoints
+
+    class DummyScaleEstimator:
+        def determine_scales(self, cfg, cps):
+            return 1.0, 1.0
+
+    class DummyM3C2Executor:
+        def run_m3c2(
+            self, cfg, comp, ref, cps, normal, projection, out_base, tag
+        ):
+            return distances, None, None
+
+    class DummyStatisticsRunner:
+        def compute_statistics(self, cfg, comparison, reference, tag):
+            pass
+
+    class DummyParamManager:
+        def save_params(self, cfg, normal, projection, out_base, tag):
+            pass
+
+        def handle_existing_params(self, cfg, out_base, tag):
+            return np.nan, np.nan
+
+    cfg = SimpleNamespace(
+        process_python_CC="cfg",
+        use_existing_params=False,
+        only_stats=False,
+    )
+
+    processor = MulticloudProcessor(
+        data_loader=DummyDataLoader(),
+        scale_estimator=DummyScaleEstimator(),
+        m3c2_executor=DummyM3C2Executor(),
+        statistics_runner=DummyStatisticsRunner(),
+        param_manager=DummyParamManager(),
+    )
+
+    processor.process(cfg, tag="run")
+
+    ply_file = tmp_path / "cfg_run_m3c2_distances.ply"
+    assert ply_file.is_file()
+
+    ply = PlyData.read(ply_file)
+    distances_read = ply["vertex"]["distance"]
+    assert any(np.isnan(distances_read))
+


### PR DESCRIPTION
## Summary
- export M3C2 distances to a PLY file in `MulticloudProcessor`
- cover PLY export with a unit test ensuring NaNs are preserved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d3b65cc8323aa1843ebfaee15fe