### PR TITLE
Add error handling tests for PLY exporter

### DIFF
--- a/tests/test_pipeline/test_ply_exporter.py
+++ b/tests/test_pipeline/test_ply_exporter.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from plyfile import PlyData
 
 from m3c2.exporter.ply_exporter import export_xyz_distance
@@ -24,4 +25,55 @@ def test_export_xyz_distance(tmp_path):
     np.testing.assert_array_equal(vertex["x"], points[:, 0])
     np.testing.assert_array_equal(vertex["y"], points[:, 1])
     np.testing.assert_array_equal(vertex["z"], points[:, 2])
+
+
+def test_export_xyz_distance_missing_dependency(monkeypatch, tmp_path):
+    points = np.zeros((2, 3), dtype=np.float32)
+    distances = np.zeros(2, dtype=np.float32)
+    outliers = np.zeros(2, dtype=np.uint8)
+    outply = tmp_path / "cloud.ply"
+
+    monkeypatch.setattr("m3c2.exporter.ply_exporter.PlyData", None)
+    monkeypatch.setattr("m3c2.exporter.ply_exporter.PlyElement", None)
+
+    with pytest.raises(RuntimeError):
+        export_xyz_distance(points, distances, outliers, str(outply))
+
+    assert not outply.exists()
+
+
+def test_export_xyz_distance_invalid_points_shape(tmp_path):
+    points = np.zeros((2, 2), dtype=np.float32)
+    distances = np.zeros(2, dtype=np.float32)
+    outliers = np.zeros(2, dtype=np.uint8)
+    outply = tmp_path / "cloud.ply"
+
+    with pytest.raises(ValueError):
+        export_xyz_distance(points, distances, outliers, str(outply))
+
+    assert not outply.exists()
+
+
+def test_export_xyz_distance_invalid_distances_length(tmp_path):
+    points = np.zeros((2, 3), dtype=np.float32)
+    distances = np.zeros(3, dtype=np.float32)
+    outliers = np.zeros(2, dtype=np.uint8)
+    outply = tmp_path / "cloud.ply"
+
+    with pytest.raises(ValueError):
+        export_xyz_distance(points, distances, outliers, str(outply))
+
+    assert not outply.exists()
+
+
+def test_export_xyz_distance_invalid_outliers_length(tmp_path):
+    points = np.zeros((2, 3), dtype=np.float32)
+    distances = np.zeros(2, dtype=np.float32)
+    outliers = np.zeros(3, dtype=np.uint8)
+    outply = tmp_path / "cloud.ply"
+
+    with pytest.raises(ValueError):
+        export_xyz_distance(points, distances, outliers, str(outply))
+
+    assert not outply.exists()
 


### PR DESCRIPTION
## Summary
- Add tests covering missing `plyfile` dependency for `export_xyz_distance`
- Add tests for invalid shapes in `export_xyz_distance` inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc41c471f88323b42780399650ed37