### PR TITLE
Add overlay color strategy tests and grouped bar test

### DIFF
--- a/tests/test_report_pipeline/test_color_mapping.py
+++ b/tests/test_report_pipeline/test_color_mapping.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from pathlib import Path
 from unittest.mock import MagicMock, call
 
+import pytest
+
 from report_pipeline.domain import DistanceFile
 from report_pipeline.plotting import figure_factory
 
@@ -47,3 +49,63 @@ def test_by_label_strategy_deterministic_across_calls(monkeypatch):
     first = axes[0].hist.call_args_list[1].kwargs["color"]
     second = axes[1].hist.call_args_list[0].kwargs["color"]
     assert first == second
+
+
+def test_make_overlay_by_label_shows_legend(monkeypatch):
+    items = [
+        DistanceFile(path=Path("g1/a.txt"), label="a"),
+        DistanceFile(path=Path("g2/b.txt"), label="b"),
+    ]
+    monkeypatch.setattr(figure_factory, "load_distance_series", lambda p: [1, 2, 3])
+    fig = MagicMock()
+    ax = MagicMock()
+    monkeypatch.setattr(figure_factory.plt, "subplots", lambda: (fig, ax))
+
+    figure_factory.make_overlay(items, color_strategy="by_label", show_legend=True)
+    colors = [call.kwargs.get("color") for call in ax.hist.call_args_list]
+    assert colors[0] != colors[1]
+    ax.legend.assert_called_once()
+
+
+def test_make_overlay_by_folder_hides_legend(monkeypatch):
+    items = [
+        DistanceFile(path=Path("g1/a.txt"), label="a"),
+        DistanceFile(path=Path("g2/b.txt"), label="b"),
+        DistanceFile(path=Path("g1/c.txt"), label="c"),
+    ]
+    monkeypatch.setattr(figure_factory, "load_distance_series", lambda p: [1, 2, 3])
+    fig = MagicMock()
+    ax = MagicMock()
+    monkeypatch.setattr(figure_factory.plt, "subplots", lambda: (fig, ax))
+
+    figure_factory.make_overlay(items, color_strategy="by_folder", show_legend=False)
+    colors = [call.kwargs.get("color") for call in ax.hist.call_args_list]
+    assert colors[0] == colors[2]
+    assert colors[0] != colors[1]
+    ax.legend.assert_not_called()
+
+
+def test_make_overlay_auto_strategy_duplicates(monkeypatch):
+    items = [
+        DistanceFile(path=Path("g1/a.txt"), label="dup"),
+        DistanceFile(path=Path("g2/b.txt"), label="dup"),
+        DistanceFile(path=Path("g1/c.txt"), label="c"),
+        DistanceFile(path=Path("g1/d.txt"), label="d"),
+    ]
+    monkeypatch.setattr(figure_factory, "load_distance_series", lambda p: [1, 2, 3])
+    fig = MagicMock()
+    ax = MagicMock()
+    monkeypatch.setattr(figure_factory.plt, "subplots", lambda: (fig, ax))
+
+    figure_factory.make_overlay(items, color_strategy="auto")
+    colors = [call.kwargs.get("color") for call in ax.hist.call_args_list]
+    assert colors[1] == colors[2]
+    ax.legend.assert_called_once()
+
+
+def test_make_overlay_invalid_color_strategy(monkeypatch):
+    items = [DistanceFile(path=Path("a.txt"), label="a")]
+    monkeypatch.setattr(figure_factory, "load_distance_series", lambda p: [1, 2, 3])
+
+    with pytest.raises(ValueError):
+        figure_factory.make_overlay(items, color_strategy="invalid")

--- a/tests/test_report_pipeline/test_figure_factory.py
+++ b/tests/test_report_pipeline/test_figure_factory.py
@@ -69,3 +69,28 @@ def test_make_passing_bablok(monkeypatch):
     monkeypatch.setattr(figure_factory, "load_distance_series", lambda p: data[p.name])
     figs = figure_factory.make_passing_bablok(items)
     assert len(figs) == 1
+
+
+def test_make_grouped_bar_creates_bars_for_each_group(monkeypatch):
+    items = [
+        DistanceFile(path=Path("with_a.txt"), label="A", group="WITH"),
+        DistanceFile(path=Path("inl_a.txt"), label="A", group="INLIER"),
+        DistanceFile(path=Path("with_b.txt"), label="B"),
+        DistanceFile(path=Path("inl_b.txt"), label="B", group="INLIER"),
+    ]
+    monkeypatch.setattr(figure_factory, "load_distance_series", lambda p: np.array([1, 2]))
+    fig = MagicMock()
+    ax0 = MagicMock()
+    ax1 = MagicMock()
+
+    def fake_subplots(*args, **kwargs):
+        return fig, [ax0, ax1]
+
+    monkeypatch.setattr(figure_factory.plt, "subplots", fake_subplots)
+
+    figure_factory.make_grouped_bar(items)
+
+    assert ax0.bar.call_count == 2
+    assert ax1.bar.call_count == 2
+    for call in ax0.bar.call_args_list + ax1.bar.call_args_list:
+        assert len(call.args[0]) == 2


### PR DESCRIPTION
## Summary
- expand make_overlay tests for label, folder, auto and invalid color strategies
- verify legend visibility via show_legend parameter
- add grouped bar test validating WITH/INLIER bar counts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc41c610ec832386cf2f87a57aa541