### PR TITLE
Add test for PDF writer empty figure case

### DIFF
--- a/tests/test_report_pipeline/test_pdf_writer.py
+++ b/tests/test_report_pipeline/test_pdf_writer.py
@@ -1,6 +1,7 @@
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
+import pytest
 from report_pipeline.pdf import writer
 
 
@@ -13,3 +14,10 @@ def test_write_creates_pdf(tmp_path):
     assert pdf_path.exists()
     assert pdf_path.suffix == '.pdf'
     assert pdf_path.read_bytes().startswith(b'%PDF')
+
+
+def test_write_empty_raises(tmp_path):
+    out_path = tmp_path / "out.pdf"
+    with pytest.raises(ValueError):
+        writer.write([], out_path, "Title")
+    assert not out_path.exists()


### PR DESCRIPTION
## Summary
- add pytest test ensuring PDF writer raises ValueError when given no figures
- verify no file is created when write is called with empty figure list

## Testing
- `pytest tests/test_report_pipeline/test_pdf_writer.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc41c736688323a4eb5c62ada88030