### PR TITLE
Add tests for group normalization and label parsing

### DIFF
--- a/tests/test_report_pipeline/test_domain.py
+++ b/tests/test_report_pipeline/test_domain.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from report_pipeline.domain import normalize_group, parse_label_group
+
+
+def test_normalize_group_trailing_digits():
+    assert normalize_group("g12") == "g"
+
+
+def test_normalize_group_none():
+    assert normalize_group(None) is None
+
+
+def test_parse_label_group_with_group():
+    label, group = parse_label_group(Path("sample__g3.txt"))
+    assert label == "sample"
+    assert group == "g"
+
+
+def test_parse_label_group_without_group():
+    label, group = parse_label_group(Path("sample.txt"))
+    assert label == "sample"
+    assert group is None


### PR DESCRIPTION
## Summary
- Add unit tests for normalize_group covering numeric suffix stripping and None
- Test parse_label_group with filenames both containing and lacking group info

## Testing
- `pytest tests/test_report_pipeline/test_domain.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc41c7b47c8323a2c85030bc3d76ff