### PR TITLE
Add tests for folder and file builder validations

### DIFF
--- a/tests/test_report_pipeline/test_strategies.py
+++ b/tests/test_report_pipeline/test_strategies.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import pytest
 
 from report_pipeline.strategies.folder import FolderJobBuilder
@@ -18,6 +17,36 @@ def test_folder_job_builder_sorts(tmp_path):
     assert groups == ["g", "g"]
 
 
+def test_folder_job_builder_group_by_folder(tmp_path):
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "alpha" / "a.txt").write_text("1\n")
+    (tmp_path / "alpha" / "sub").mkdir()
+    (tmp_path / "alpha" / "sub" / "b.txt").write_text("1\n")
+    (tmp_path / "beta").mkdir()
+    (tmp_path / "beta" / "c.txt").write_text("1\n")
+    builder = FolderJobBuilder(folder=tmp_path, pattern="**/*.txt", group_by_folder=True)
+    jobs = sorted(builder.build_jobs(), key=lambda j: j.page_title)
+    assert [job.page_title for job in jobs] == ["alpha", "beta"]
+    labels = {job.page_title: [item.label for item in job.items] for job in jobs}
+    assert labels["alpha"] == ["a", "b"]
+    assert labels["beta"] == ["c"]
+
+
+def test_folder_job_builder_missing_directory(tmp_path):
+    missing = tmp_path / "missing"
+    builder = FolderJobBuilder(folder=missing)
+    with pytest.raises(FileNotFoundError):
+        builder.build_jobs()
+
+
+def test_folder_job_builder_paired_validation(tmp_path):
+    for name in ["a__g.txt", "b__g.txt", "c__g.txt"]:
+        (tmp_path / name).write_text("1\n")
+    builder = FolderJobBuilder(folder=tmp_path, paired=True)
+    with pytest.raises(ValueError):
+        builder.build_jobs()
+
+
 
 def test_files_job_builder_missing_file(tmp_path):
     existing = tmp_path / "a.txt"
@@ -32,6 +61,17 @@ def test_files_job_builder_requires_two_files(tmp_path):
     a = tmp_path / "a.txt"
     a.write_text("1\n")
     builder = FilesJobBuilder(files=[a])
+    with pytest.raises(ValueError):
+        builder.build_jobs()
+
+
+def test_files_job_builder_paired_validation(tmp_path):
+    a = tmp_path / "a__g.txt"
+    b = tmp_path / "b__g.txt"
+    c = tmp_path / "c__g.txt"
+    for f in (a, b, c):
+        f.write_text("1\n")
+    builder = FilesJobBuilder(files=[a, b, c], paired=True)
     with pytest.raises(ValueError):
         builder.build_jobs()
 


### PR DESCRIPTION
## Summary
- test FolderJobBuilder grouping by subfolder
- ensure FolderJobBuilder handles missing folders and paired validation
- validate FilesJobBuilder paired option with odd number of files

## Testing
- `pytest tests/test_report_pipeline/test_strategies.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc41c8cc30832392f4496300fe13d1