### PR TITLE
docs: add CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,34 @@ python -m main --data_dir ./data --folders 0342-0349 --filename_reference refere
 
 Outputs, statistics, and logs are written to dataset folders and the `outputs/` directory.
 
+## CLI Examples
+
+### Single Cloud Statistics
+
+```bash
+python -m main --data_dir ./data --folders scan1 --filename_singlecloud surface.las --stats_singleordistance single
+python -m main --data_dir ./data --folders scanA scanB --filename_singlecloud points.ply --stats_singleordistance single --output_format json
+```
+
+### Distance Metrics
+
+```bash
+python -m main --data_dir ./data --folders pair_01 --filename_reference ref.ply --filename_comparison cmp.ply --stats_singleordistance distance
+python -m main --data_dir ./data --folders pair_A pair_B --filename_reference ref.las --filename_comparison cmp.las --stats_singleordistance distance --use_subsampled_corepoints 5 --outlier_detection_method nmad
+```
+
+### Plot Generation
+
+The reporting workflow is exposed through the `report_pipeline` commands. Invoke
+it either with `python -m report_pipeline` or, when installed as a package, via
+the `m3c2-report` console script. Some typical commands are:
+
+```bash
+python -m report_pipeline folder --folder results/case_07 --pattern "*_distances.txt" --out case_07.pdf
+python -m report_pipeline multifolder --folders results/c1 results/c2 --pattern "*_dist.txt" --paired --out all_cases.pdf
+python -m report_pipeline files --files a1.txt b1.txt a2.txt --out ai_overlay.pdf --legend
+```
+
 ## Logging
 
 Control verbosity with the `--log_level` option or by setting the `LOG_LEVEL`
@@ -103,15 +131,3 @@ Global settings for the pipeline and report generation live in `config.json` and
 | `outlier_detection_method`| string         | `"rmse"`         | Outlier detection method (`rmse`, `mad`, `nmad`, `std`). |
 | `outlier_multiplicator`   | float          | `3.0`            | Multiplicator applied by the chosen outlier method. |
 | `log_level`               | string         | `"INFO"`         | Logging level for output (overrides `logging.level`). |
-
-## Report Pipeline CLI Examples
-
-The reporting workflow is exposed through the `report_pipeline` commands.
-Invoke it either with `python -m report_pipeline` or, when installed as a
-package, via the `m3c2-report` console script. Some typical commands are:
-
-```bash
-python -m report_pipeline folder --folder results/case_07 --pattern "*_distances.txt" --out case_07.pdf
-python -m report_pipeline multifolder --folders results/c1 results/c2 --pattern "*_dist.txt" --paired --out all_cases.pdf
-python -m report_pipeline files --files a1.txt b1.txt a2.txt --out ai_overlay.pdf --legend
-```


### PR DESCRIPTION
## Summary
- document single-cloud statistics commands
- add distance metric examples
- show how to generate plots via `report_pipeline`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc468e0ba483239614621099ade318