### PR TITLE
Allow CLI boolean flags to parse true/false values

### DIFF
--- a/m3c2/cli/argparse_gui.py
+++ b/m3c2/cli/argparse_gui.py
@@ -136,9 +136,9 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
             )
             desc_widget.grid(row=row, column=2, sticky="w", padx=5, pady=5)
 
-        if action.option_strings and action.nargs == 0 and (
-            action.const is True
-            or (bool_action is not None and isinstance(action, bool_action))
+        if action.option_strings and (
+            (bool_action is not None and isinstance(action, bool_action))
+            or (action.const is True and action.nargs in (0, "?"))
         ):
             var = tk.BooleanVar(value=bool(action.default))
             widget = tk.Checkbutton(root, variable=var)
@@ -187,6 +187,11 @@ def run_gui(parser: argparse.ArgumentParser, main_func) -> None:
                         if var.get() != action.default:
                             opt = action.option_strings[0] if var.get() else action.option_strings[1]
                             argv.append(opt)
+                    elif action.nargs in (0, "?"):
+                        if var.get() != action.default:
+                            argv.append(action.option_strings[0])
+                            if action.nargs == "?":
+                                argv.append(str(var.get()).lower())
                     else:
                         if var.get() != action.default:
                             argv.append(action.option_strings[0])

--- a/m3c2/cli/cli.py
+++ b/m3c2/cli/cli.py
@@ -11,6 +11,38 @@ from m3c2.config.logging_config import setup_logging
 from m3c2.pipeline.batch_orchestrator import BatchOrchestrator
 from m3c2.config.pipeline_config import PipelineConfig
 
+
+def _str2bool(value: str) -> bool:
+    """Return a boolean for a variety of truthy/falsey strings.
+
+    Parameters
+    ----------
+    value:
+        Input value provided on the command line.
+
+    Returns
+    -------
+    bool
+        ``True`` for values like ``"true"`` or ``"1"`` and ``False`` for
+        ``"false"`` or ``"0"``.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If ``value`` cannot be interpreted as a boolean.
+    """
+
+    if isinstance(value, bool):
+        return value
+
+    text = value.lower()
+    if text in {"1", "true", "t", "yes", "y"}:
+        return True
+    if text in {"0", "false", "f", "no", "n"}:
+        return False
+
+    raise argparse.ArgumentTypeError("Boolean value expected.")
+
 class CLIApp:
     """Command line application wrapper for the pipeline."""
 
@@ -117,7 +149,9 @@ class CLIApp:
         )
         parser.add_argument(
             "--only_stats",
-            action=argparse.BooleanOptionalAction,
+            type=_str2bool,
+            nargs="?",
+            const=True,
             help="Only compute statistics based on existing distance files (no M3C2 processing).",
         )
         parser.add_argument(
@@ -153,7 +187,9 @@ class CLIApp:
         )
         parser.add_argument(
             "--use_existing_params",
-            action=argparse.BooleanOptionalAction,
+            type=_str2bool,
+            nargs="?",
+            const=True,
             help="Use existing parameters in folder if available.",
         )
         parser.add_argument(


### PR DESCRIPTION
## Summary
- add `_str2bool` helper to convert various true/false strings
- let `--only_stats` and `--use_existing_params` accept explicit boolean values
- teach GUI helper to handle new boolean flags

## Testing
- `pytest -q`
- `python -m main --only_stats false` *(fails: The specified data directory does not exist or is not a directory: /workspace/M3C2/data)*

------
https://chatgpt.com/codex/tasks/task_e_68bc599b158c8323a199136bfc9283dc