### PR TITLE
Remove unused XLSX filename helpers

### DIFF
--- a/m3c2/config/filenames_config.py
+++ b/m3c2/config/filenames_config.py
@@ -99,9 +99,6 @@ class FileNames:
     STATS_CLOUDS_XLSX = (
         "outputs/{project}_output/{project}_m3c2_stats_clouds.xlsx"
     )
-    STATS_ALL_XLSX = "m3c2_stats_all.xlsx"
-    STATS_CLOUDS_XLSX_SIMPLE = "m3c2_stats_clouds.xlsx"
-    CLOUD_STATS_XLSX = "cloud_stats.xlsx"
 
     # Report service patterns
     REPORT_CLOUD_MOVED_DISTANCES = (
@@ -164,18 +161,6 @@ class FileNames:
         if ext == "xlsx":
             return FileNames.STATS_CLOUDS_XLSX.format(project=project)
         raise ValueError("Unsupported extension: {ext}")
-
-    @staticmethod
-    def stats_all_xlsx() -> str:
-        return FileNames.STATS_ALL_XLSX
-
-    @staticmethod
-    def stats_clouds_xlsx() -> str:
-        return FileNames.STATS_CLOUDS_XLSX_SIMPLE
-
-    @staticmethod
-    def cloud_stats_xlsx() -> str:
-        return FileNames.CLOUD_STATS_XLSX
 
     @staticmethod
     def report_cloud_comparison_distances(prefix: str, fid: str) -> str:


### PR DESCRIPTION
## Summary
- remove redundant XLSX filename helper constants and accessors
- clean up `FileNames` to only expose used stats paths

## Testing
- `pytest -q`
- `flake8 m3c2/config/filenames_config.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7c56ee688323ac9daaa64fdb49b2