### PR TITLE
Move module docstrings above future imports

### DIFF
--- a/m3c2/cli/cli.py
+++ b/m3c2/cli/cli.py
@@ -1,4 +1,5 @@
 """Command-line interface for the M3C2 pipeline."""
+
 from __future__ import annotations
 
 import argparse

--- a/m3c2/config/filenames_config.py
+++ b/m3c2/config/filenames_config.py
@@ -1,3 +1,5 @@
+"""Resolved filename components derived from a :class:`PipelineConfig`."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -7,7 +9,6 @@ from m3c2.config.pipeline_config import PipelineConfig
 
 @dataclass(frozen=True)
 class FileNameParams:
-    """Resolved filename components derived from a :class:`PipelineConfig`."""
 
     prefix: str
     tag: str

--- a/m3c2/importer/converters.py
+++ b/m3c2/importer/converters.py
@@ -1,6 +1,7 @@
+"""Utilities for converting point cloud formats to XYZ."""
+
 from __future__ import annotations
 
-"""Utilities for converting point cloud formats to XYZ."""
 
 from pathlib import Path
 import logging

--- a/m3c2/importer/data_loader.py
+++ b/m3c2/importer/data_loader.py
@@ -1,4 +1,5 @@
 """Utility class for loading input data for the M3C2 pipeline."""
+
 from __future__ import annotations
 
 import logging

--- a/m3c2/importer/file_detection.py
+++ b/m3c2/importer/file_detection.py
@@ -1,6 +1,7 @@
+"""Helper utilities for detecting point cloud file formats."""
+
 from __future__ import annotations
 
-"""Helper utilities for detecting point cloud file formats."""
 
 from pathlib import Path
 import logging

--- a/m3c2/importer/loaders/las.py
+++ b/m3c2/importer/loaders/las.py
@@ -1,6 +1,7 @@
+"""Loader for LAS/LAZ point cloud files."""
+
 from __future__ import annotations
 
-"""Loader for LAS/LAZ point cloud files."""
 
 from pathlib import Path
 

--- a/m3c2/importer/loaders/ply.py
+++ b/m3c2/importer/loaders/ply.py
@@ -1,6 +1,7 @@
+"""Loader for PLY point cloud files."""
+
 from __future__ import annotations
 
-"""Loader for PLY point cloud files."""
 
 from pathlib import Path
 

--- a/m3c2/importer/loaders/xyz.py
+++ b/m3c2/importer/loaders/xyz.py
@@ -1,6 +1,7 @@
+"""Loader for plain XYZ point cloud files."""
+
 from __future__ import annotations
 
-"""Loader for plain XYZ point cloud files."""
 
 from pathlib import Path
 

--- a/report_pipeline/__main__.py
+++ b/report_pipeline/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Command-line entry point for the report pipeline.
 
 Running ``python -m report_pipeline`` or the corresponding console script
@@ -7,6 +5,9 @@ invokes this module.  It parses command-line arguments via
 :mod:`report_pipeline.cli` and executes the lightweight report pipeline,
 producing a PDF report from distance files.
 """
+
+from __future__ import annotations
+
 
 from pathlib import Path
 from typing import Sequence

--- a/report_pipeline/cli.py
+++ b/report_pipeline/cli.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Command line interface for the simple report pipeline.
 
 This module exposes a minimal argument parser with three subcommands for
@@ -26,6 +24,9 @@ orchestration and returns the builder for use by higher level code.  When the
 ``--dry-run`` flag is supplied the function returns ``None`` without creating a
 builder.
 """
+
+from __future__ import annotations
+
 
 from pathlib import Path
 from typing import Callable, Sequence

--- a/report_pipeline/orchestrator.py
+++ b/report_pipeline/orchestrator.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Lightweight orchestration for building PDF reports from plot jobs.
 
 The :class:`ReportOrchestrator` coordinates the interaction between a plotter
@@ -7,6 +5,9 @@ object and a PDF writer.  Given a sequence of :class:`~report_pipeline.domain.Pl
 instances it requests plots from the plotter, collects the resulting figures and
 finally delegates to the PDF writer to persist the figures as a report.
 """
+
+from __future__ import annotations
+
 
 from pathlib import Path
 

--- a/report_pipeline/pdf/writer.py
+++ b/report_pipeline/pdf/writer.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Utilities to persist matplotlib figures as a PDF document.
 
 The :func:`write` function accepts a sequence of matplotlib figures and stores
@@ -7,6 +5,9 @@ them in a PDF file.  Basic metadata such as title, creation date and the
 command used to invoke the program are embedded in the resulting document.  The
 path to the created PDF is returned to the caller.
 """
+
+from __future__ import annotations
+
 
 from datetime import datetime
 import sys

--- a/report_pipeline/plotting/figure_factory.py
+++ b/report_pipeline/plotting/figure_factory.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Factory functions creating matplotlib figures for distance overlays.
 
 The module focuses on a single high level function :func:`make_overlay` which
@@ -11,6 +9,9 @@ smaller than the number of items, multiple figures are created.  The caller is
 responsible for further processing, for instance writing the figures to a PDF
 report.
 """
+
+from __future__ import annotations
+
 
 from itertools import islice
 from hashlib import sha256

--- a/report_pipeline/plotting/loader.py
+++ b/report_pipeline/plotting/loader.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Simple utilities for reading numeric distance data from text files.
 
 This module provides a lightweight :func:`load_distance_series` function that
@@ -8,6 +6,9 @@ Only finite values are returned; non-numeric entries trigger a ``ValueError``.
 The implementation is intentionally small and does not depend on any project
 specific infrastructure which makes it easy to test in isolation.
 """
+
+from __future__ import annotations
+
 
 from pathlib import Path
 

--- a/report_pipeline/strategies/base.py
+++ b/report_pipeline/strategies/base.py
@@ -1,6 +1,7 @@
+"""Protocols for job building strategies."""
+
 from __future__ import annotations
 
-"""Protocols for job building strategies."""
 
 from typing import Protocol
 

--- a/report_pipeline/strategies/files.py
+++ b/report_pipeline/strategies/files.py
@@ -1,6 +1,7 @@
+"""Strategy building jobs from explicit distance files."""
+
 from __future__ import annotations
 
-"""Strategy building jobs from explicit distance files."""
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/report_pipeline/strategies/folder.py
+++ b/report_pipeline/strategies/folder.py
@@ -1,6 +1,7 @@
+"""Strategy producing jobs from all distance files in a folder."""
+
 from __future__ import annotations
 
-"""Strategy producing jobs from all distance files in a folder."""
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/report_pipeline/strategies/multifolder.py
+++ b/report_pipeline/strategies/multifolder.py
@@ -1,6 +1,7 @@
+"""Strategy assembling jobs from multiple folders using a file pattern."""
+
 from __future__ import annotations
 
-"""Strategy assembling jobs from multiple folders using a file pattern."""
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/tests/test_io/test_data_loader_singlecloud.py
+++ b/tests/test_io/test_data_loader_singlecloud.py
@@ -1,4 +1,5 @@
 """Tests for :mod:`m3c2.importer.data_loader`."""
+
 from __future__ import annotations
 
 import os

--- a/tests/test_io/test_loaders.py
+++ b/tests/test_io/test_loaders.py
@@ -1,6 +1,7 @@
+"""Tests for simple point cloud loaders."""
+
 from __future__ import annotations
 
-"""Tests for simple point cloud loaders."""
 
 from pathlib import Path
 import io


### PR DESCRIPTION
## Summary
- place module docstrings before `from __future__ import annotations`
- ensure a blank line separates docstrings and imports across CLI, importer, report pipeline and test modules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc7d51a9408323bb85cb4f5b15fad5