### PR TITLE
Refine statistics runner naming and clarify output paths

### DIFF
--- a/tests/test_pipeline/test_statistics_runner.py
+++ b/tests/test_pipeline/test_statistics_runner.py
@@ -52,7 +52,7 @@ def test_compute_statistics_distance(monkeypatch, caplog):
 
     runner = StatisticsRunner(output_format="excel")
     caplog.set_level(logging.INFO)
-    runner.compute_statistics(cfg, comparison=None, reference=None, tag="reference")
+    runner.compute_statistics(cfg, comparison=None, reference=None, run_tag="reference")
 
     assert called["out_path"].endswith("proj_m3c2_stats_distances.xlsx")
     assert any("Stats on Distance" in rec.message for rec in caplog.records)
@@ -112,7 +112,7 @@ def test_invalid_output_format():
     runner = StatisticsRunner(output_format="xml")
     cfg = SimpleNamespace(stats_singleordistance="distance", folder_id="fid", filename_reference="reference")
     try:
-        runner.compute_statistics(cfg, comparison=None, reference=None, tag="reference")
+        runner.compute_statistics(cfg, comparison=None, reference=None, run_tag="reference")
     except ValueError:
         pass
     else:


### PR DESCRIPTION
## Summary
- Rename cfg→config, tag→run_tag and out_path→output_path in statistics runner
- Document handler decision branches and output generation
- Update tests for new parameter names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc7da262388323b13f65c774e8199f