### PR TITLE
Refactor executor variable names for clarity and add comments

### DIFF
--- a/tests/test_pipeline/test_m3c2_executor.py
+++ b/tests/test_pipeline/test_m3c2_executor.py
@@ -56,8 +56,8 @@ def test_run_m3c2_writes_outputs(tmp_path, monkeypatch, caplog):
         corepoints,
         normal=0.5,
         projection=0.5,
-        out_base=str(tmp_path),
-        tag="run",
+        output_dir=str(tmp_path),
+        run_tag="run",
     )
 
     assert np.allclose(d[0], 1.0) and np.isnan(d[1])
@@ -112,8 +112,8 @@ def test_run_m3c2_skips_coordinates_on_mismatch(tmp_path, monkeypatch, caplog):
         corepoints,
         normal=0.5,
         projection=0.5,
-        out_base=str(tmp_path),
-        tag="run",
+        output_dir=str(tmp_path),
+        run_tag="run",
     )
 
     coords_file = tmp_path / "cfg_run_m3c2_distances_coordinates.txt"

--- a/tests/test_pipeline/test_multicloud_processor.py
+++ b/tests/test_pipeline/test_multicloud_processor.py
@@ -34,7 +34,7 @@ def test_process_exports_ply_with_nan(tmp_path):
 
     class DummyM3C2Executor:
         def run_m3c2(
-            self, cfg, comp, ref, cps, normal, projection, out_base, tag
+            self, cfg, comp, ref, cps, normal, projection, output_dir, run_tag
         ):
             return distances, None, None
 


### PR DESCRIPTION
## Summary
- Rename M3C2 executor parameters and internal variables for clarity (`config`, `output_dir`, `run_tag`, etc.)
- Add comments highlighting computation start, logging, persistence, and data validation steps
- Update tests and dummy executors to reflect new interface

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc7da397288323a4f294c3c942a89b