### PR TITLE
Rename ParamManager arguments for clarity

### DIFF
--- a/m3c2/pipeline/singlecloud_processor.py
+++ b/m3c2/pipeline/singlecloud_processor.py
@@ -35,8 +35,8 @@ class SinglecloudProcessor:
             normal, projection = self.scale_estimator.determine_scales(
                 cfg, single_cloud
             )
-            out_base = os.path.join(cfg.data_dir, cfg.folder_id)
-            self.param_manager.save_params(cfg, normal, projection, out_base, tag)
+            output_dir = os.path.join(cfg.data_dir, cfg.folder_id)
+            self.param_manager.save_params(cfg, normal, projection, output_dir, tag)
         else:
             logger.error("[Params] Ungültige/Fehlende Parameter in Config")
             normal = projection = np.nan

--- a/tests/test_pipeline/test_multicloud_processor.py
+++ b/tests/test_pipeline/test_multicloud_processor.py
@@ -47,10 +47,10 @@ def test_process_exports_ply_with_nan(tmp_path):
             pass
 
     class DummyParamManager:
-        def save_params(self, cfg, normal, projection, out_base, tag):
+        def save_params(self, config, normal, projection, output_dir, tag):
             pass
 
-        def handle_existing_params(self, cfg, out_base, tag):
+        def handle_existing_params(self, config, output_dir, tag):
             return np.nan, np.nan
 
     cfg = SimpleNamespace(

--- a/tests/test_pipeline/test_singlecloud_processor.py
+++ b/tests/test_pipeline/test_singlecloud_processor.py
@@ -54,9 +54,9 @@ def test_process_single_cloud(tmp_path):
             calls["stats"] = SimpleNamespace(cfg=cfg, arr=arr, normal=normal)
 
     class DummyParamManager:
-        def save_params(self, cfg, normal, projection, out_base, tag):
+        def save_params(self, config, normal, projection, output_dir, tag):
             calls["save_params"] = SimpleNamespace(
-                cfg=cfg, normal=normal, projection=projection, out_base=out_base, tag=tag
+                cfg=config, normal=normal, projection=projection, output_dir=output_dir, tag=tag
             )
 
         def handle_override_params(self, cfg):  # pragma: no cover - should not be called
@@ -75,7 +75,7 @@ def test_process_single_cloud(tmp_path):
 
     assert calls["load_data"].mode == "singlecloud"
     assert calls["determine_scales"].arr is cloud
-    assert calls["save_params"].out_base == os.path.join(cfg.data_dir, cfg.folder_id)
+    assert calls["save_params"].output_dir == os.path.join(cfg.data_dir, cfg.folder_id)
     assert calls["stats"].normal == 1.0
     assert "handle_override_params" not in calls
 


### PR DESCRIPTION
## Summary
- rename cfg->config and out_base->output_dir in ParamManager
- clarify param file handling and override precedence with comments
- update processors and tests for new ParamManager signature

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc7da5c0748323bec7582d52a3bb20